### PR TITLE
Improve contributor experience

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,3 @@
-bin/
 README.md
 Dockerfile
 LICENSE

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,20 +7,13 @@ matrix:
     - go: 1.9
     - go: 1.8
 
-before_install:
-  - go get github.com/mitchellh/gox # go tool for cross compiling
-  - go get github.com/inconshreveable/mousetrap # needed for windows builds
-
 install:
-  - go get github.com/RadhiFadlillah/shiori
+  - bin/setup
 
 script:
-  - go get -t -v ./...
   - diff -u <(echo -n) <(gofmt -d .)
-  - go vet $(go list ./... | grep -v /vendor/)
-  - go test -v -race ./...
-  # only build binaries from the latest Go release.
-  - if [ "${LATEST}" = "true" ]; then gox -os="linux darwin windows" -arch="amd64" -output "shiori_{{.OS}}_{{.Arch}}" -ldflags "-X main.Rev=`git rev-parse --short HEAD`" -verbose ./...; fi
+  - bin/test
+  - if [ "${LATEST}" == "true" ]; then OSSES="linux darwin windows" bin/build; else bin/build; fi
 
 deploy:
   provider: releases

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,15 +5,15 @@ RUN apk update \
 
 WORKDIR /go/src/github.com/RadhiFadlillah/shiori
 COPY . .
-RUN go get -d -v ./...
-RUN go build -o shiori main.go
+RUN bin/setup
+RUN bin/build
 
 FROM alpine:latest
 
 ENV ENV_SHIORI_DB /srv/shiori.db
 
 RUN apk --no-cache add dumb-init ca-certificates
-COPY --from=builder /go/src/github.com/RadhiFadlillah/shiori/shiori /usr/local/bin/shiori
+COPY --from=builder /go/src/github.com/RadhiFadlillah/shiori/shiori_linux_amd64 /usr/local/bin/shiori
 
 WORKDIR /srv/
 RUN touch shiori.db

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,18 @@
+.PHONY: all
+all: build
+
+.PHONY: build
+build:
+	bin/build
+
+.PHONY: docker_build
+docker_build:
+	bin/docker/build
+
+.PHONY: setup
+setup:
+	bin/setup
+
+.PHONY: test
+setup:
+	bin/test

--- a/README.md
+++ b/README.md
@@ -256,6 +256,40 @@ console](#console-access-for-container). After that go along with the examples.
     ```sh
     shiori account add username
     ```
+## Contribute
+
+### Setup project
+
+To install dependencies required for development, please run the following
+command.
+
+```sh
+bin/setup
+# or
+make setup
+```
+
+### Build project
+
+To build the project, please run the following command.
+
+```sh
+bin/build
+# or
+make
+# or
+make build
+```
+
+### Build docker container
+
+There's a wrapper for building the docker container.
+
+```sh
+bin/docker/build
+# or
+make docker_build
+```
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ There's a Dockerfile that enables you to build your own dockerized Shiori (as by
 ### Build the image
 
 ```bash
-$ docker build -t shiori .
+bin/docker/build
 ```
 
 ### Run the container

--- a/bin/build
+++ b/bin/build
@@ -1,0 +1,6 @@
+#!/usr/bin/env sh
+
+: ${OSSES:=linux}
+
+echo Build project for $OSSES
+gox -os="$OSSES" -arch="amd64" -output "shiori_{{.OS}}_{{.Arch}}" -ldflags "-X main.Rev=`git rev-parse --short HEAD`" -verbose ./...

--- a/bin/docker/build
+++ b/bin/docker/build
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+: ${DOCKER_IMAGE:=radhifadlillah/shiori}
+: ${DOCKER_FILE:=Dockerfile}
+: ${WORK_DIR:=./}
+
+echo docker build $* -t $DOCKER_IMAGE -f $DOCKER_FILE $WORK_DIR
+docker build $* -t $DOCKER_IMAGE -f $DOCKER_FILE $WORK_DIR

--- a/bin/setup
+++ b/bin/setup
@@ -1,0 +1,8 @@
+#!/usr/bin/env sh
+
+echo Install cross compiler
+go get github.com/mitchellh/gox
+
+echo Install dependencies
+go get github.com/inconshreveable/mousetrap
+go get -t -v ./...

--- a/bin/test
+++ b/bin/test
@@ -1,0 +1,5 @@
+#!/usr/bin/env sh
+
+echo Testing project
+go vet $(go list ./... | grep -v /vendor/)
+go test -v -race ./...


### PR DESCRIPTION
# Preface

This extracts some commits from #66 to focus discussion on related things.

# Reason for separate PR

> BTW, I think we don't really need to add those additional scripts, especially since go command is already simple enough to use. For example, setup is just wrapper for go get and build is just wrapper for go build.

# Changes introduced

* Add scripts
* Documentation for those scripts
* ~~Migrate dependency handling to dep as it is stable and can handle that task well~~ This failed and was removed in a later iteration
* Migrate logic from `.travis.yml` to scripts to make it usable for contributors as well
* Replace logic in `Dockerfile` with scripts