### PR TITLE
Improve API consistency

### DIFF
--- a/docs/postman/shiori.postman_collection.json
+++ b/docs/postman/shiori.postman_collection.json
@@ -91,7 +91,7 @@
 					"response": []
 				},
 				{
-					"name": "/api/tag",
+					"name": "/api/tags",
 					"request": {
 						"method": "PUT",
 						"header": [
@@ -112,13 +112,13 @@
 							"raw": "{\n\t\"id\": 1,\n    \"name\": \"renamed_tag_7\"\n}"
 						},
 						"url": {
-							"raw": "{{host}}/api/tag",
+							"raw": "{{host}}/api/tags",
 							"host": [
 								"{{host}}"
 							],
 							"path": [
 								"api",
-								"tag"
+								"tags"
 							]
 						}
 					},

--- a/internal/view/js/page/home.js
+++ b/internal/view/js/page/home.js
@@ -250,7 +250,7 @@ export default {
 					return response.json();
 				})
 				.then(json => {
-					this.tags = json;
+					this.tags = json.tags;
 					this.loading = false;
 				})
 				.catch(err => {

--- a/internal/view/js/page/home.js
+++ b/internal/view/js/page/home.js
@@ -766,7 +766,7 @@ export default {
 					};
 
 					this.dialog.loading = true;
-					fetch(new URL("api/tag", document.baseURI), {
+					fetch(new URL("api/tags", document.baseURI), {
 						method: "PUT",
 						body: JSON.stringify(newData),
 						headers: { "Content-Type": "application/json" },

--- a/internal/view/js/page/home.js
+++ b/internal/view/js/page/home.js
@@ -770,9 +770,6 @@ export default {
 						method: "PUT",
 						body: JSON.stringify(newData),
 						headers: { "Content-Type": "application/json" },
-					}).then(response => {
-						if (!response.ok) throw response;
-						return response.json();
 					}).then(() => {
 						tag.name = data.newName;
 

--- a/internal/view/js/page/setting.js
+++ b/internal/view/js/page/setting.js
@@ -105,7 +105,7 @@ export default {
 				})
 				.then(json => {
 					this.loading = false;
-					this.accounts = json;
+					this.accounts = json.accounts;
 				})
 				.catch(err => {
 					this.loading = false;

--- a/internal/webserver/handler-api.go
+++ b/internal/webserver/handler-api.go
@@ -139,7 +139,7 @@ func (h *handler) apiLogout(w http.ResponseWriter, r *http.Request, ps httproute
 		h.SessionCache.Delete(sessionID)
 	}
 
-	fmt.Fprint(w, 1)
+	w.WriteHeader(http.StatusNoContent)
 }
 
 // apiGetBookmarks is handler for GET /api/bookmarks
@@ -249,7 +249,7 @@ func (h *handler) apiRenameTag(w http.ResponseWriter, r *http.Request, ps httpro
 	err = h.DB.RenameTag(tag.ID, tag.Name)
 	checkError(err)
 
-	fmt.Fprint(w, 1)
+	w.WriteHeader(http.StatusNoContent)
 }
 
 // Bookmark is the record for an URL.
@@ -360,7 +360,7 @@ func (h *handler) apiDeleteBookmark(w http.ResponseWriter, r *http.Request, ps h
 		os.Remove(archivePath)
 	}
 
-	fmt.Fprint(w, 1)
+	w.WriteHeader(http.StatusNoContent)
 }
 
 // apiUpdateBookmark is handler for PUT /api/bookmarks
@@ -659,7 +659,7 @@ func (h *handler) apiInsertAccount(w http.ResponseWriter, r *http.Request, ps ht
 	err = h.DB.SaveAccount(account)
 	checkError(err)
 
-	fmt.Fprint(w, 1)
+	w.WriteHeader(http.StatusNoContent)
 }
 
 // apiUpdateAccount is handler for PUT /api/accounts
@@ -707,7 +707,7 @@ func (h *handler) apiUpdateAccount(w http.ResponseWriter, r *http.Request, ps ht
 		h.UserCache.Delete(request.Username)
 	}
 
-	fmt.Fprint(w, 1)
+	w.WriteHeader(http.StatusNoContent)
 }
 
 // apiDeleteAccount is handler for DELETE /api/accounts
@@ -738,5 +738,5 @@ func (h *handler) apiDeleteAccount(w http.ResponseWriter, r *http.Request, ps ht
 		}
 	}
 
-	fmt.Fprint(w, 1)
+	w.WriteHeader(http.StatusNoContent)
 }

--- a/internal/webserver/handler-api.go
+++ b/internal/webserver/handler-api.go
@@ -225,8 +225,12 @@ func (h *handler) apiGetTags(w http.ResponseWriter, r *http.Request, ps httprout
 	tags, err := h.DB.GetTags()
 	checkError(err)
 
+	resp := map[string]interface{}{
+		"tags": tags,
+	}
+
 	w.Header().Set("Content-Type", "application/json")
-	err = json.NewEncoder(w).Encode(&tags)
+	err = json.NewEncoder(w).Encode(&resp)
 	checkError(err)
 }
 

--- a/internal/webserver/handler-api.go
+++ b/internal/webserver/handler-api.go
@@ -230,7 +230,7 @@ func (h *handler) apiGetTags(w http.ResponseWriter, r *http.Request, ps httprout
 	checkError(err)
 }
 
-// apiRenameTag is handler for PUT /api/tag
+// apiRenameTag is handler for PUT /api/tags
 func (h *handler) apiRenameTag(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
 	// Make sure session still valid
 	err := h.validateSession(r)

--- a/internal/webserver/handler-api.go
+++ b/internal/webserver/handler-api.go
@@ -635,8 +635,12 @@ func (h *handler) apiGetAccounts(w http.ResponseWriter, r *http.Request, ps http
 	accounts, err := h.DB.GetAccounts(database.GetAccountsOptions{})
 	checkError(err)
 
+	resp := map[string]interface{}{
+		"accounts": accounts,
+	}
+
 	w.Header().Set("Content-Type", "application/json")
-	err = json.NewEncoder(w).Encode(&accounts)
+	err = json.NewEncoder(w).Encode(&resp)
 	checkError(err)
 }
 

--- a/internal/webserver/server.go
+++ b/internal/webserver/server.go
@@ -189,7 +189,7 @@ func ServeApp(cfg Config) error {
 	router.POST(jp("/api/logout"), withLogging(hdl.apiLogout))
 	router.GET(jp("/api/bookmarks"), withLogging(hdl.apiGetBookmarks))
 	router.GET(jp("/api/tags"), withLogging(hdl.apiGetTags))
-	router.PUT(jp("/api/tag"), withLogging(hdl.apiRenameTag))
+	router.PUT(jp("/api/tags"), withLogging(hdl.apiRenameTag))
 	router.POST(jp("/api/bookmarks"), withLogging(hdl.apiInsertBookmark))
 	router.DELETE(jp("/api/bookmarks"), withLogging(hdl.apiDeleteBookmark))
 	router.PUT(jp("/api/bookmarks"), withLogging(hdl.apiUpdateBookmark))


### PR DESCRIPTION
Hello again!

This PR improves some of the resource APIs to be more aligned with REST best practices. It:

- adds response envelopes for several endpoints which had top-level JSON arrays
- :warning: **Breaking change:** changes responses containing a `1` in the body to return a `204 No Content` status with an empty body instead
- :warning: **Breaking change:** renames the `PUT /api/tag` endpoint to `/api/tags`
- updates the Postman collection

I've also generated a new bundle for the frontend since some of the API changes required changes to the associated JS files.