### PR TITLE
Fix custom title and excerpt not being saved when adding a new bookmark

### DIFF
--- a/docs/postman/shiori.postman_collection.json
+++ b/docs/postman/shiori.postman_collection.json
@@ -91,7 +91,7 @@
 					"response": []
 				},
 				{
-					"name": "/api/tag",
+					"name": "/api/tags",
 					"request": {
 						"method": "PUT",
 						"header": [
@@ -112,13 +112,13 @@
 							"raw": "{\n\t\"id\": 1,\n    \"name\": \"renamed_tag_7\"\n}"
 						},
 						"url": {
-							"raw": "{{host}}/api/tag",
+							"raw": "{{host}}/api/tags",
 							"host": [
 								"{{host}}"
 							],
 							"path": [
 								"api",
-								"tag"
+								"tags"
 							]
 						}
 					},

--- a/internal/view/js/page/home.js
+++ b/internal/view/js/page/home.js
@@ -766,7 +766,7 @@ export default {
                     };
 
                     this.dialog.loading = true;
-                    fetch("/api/tag", {
+                    fetch("/api/tags", {
                         method: "PUT",
                         body: JSON.stringify(newData),
                         headers: { "Content-Type": "application/json" },

--- a/internal/view/js/page/home.js
+++ b/internal/view/js/page/home.js
@@ -250,7 +250,7 @@ export default {
                     return response.json();
                 })
                 .then(json => {
-                    this.tags = json;
+                    this.tags = json.tags;
                     this.loading = false;
                 })
                 .catch(err => {

--- a/internal/view/js/page/setting.js
+++ b/internal/view/js/page/setting.js
@@ -105,7 +105,7 @@ export default {
                 })
                 .then(json => {
                     this.loading = false;
-                    this.accounts = json;
+                    this.accounts = json.accounts;
                 })
                 .catch(err => {
                     this.loading = false;

--- a/internal/webserver/handler-api.go
+++ b/internal/webserver/handler-api.go
@@ -222,7 +222,7 @@ func (h *handler) apiGetTags(w http.ResponseWriter, r *http.Request, ps httprout
 	checkError(err)
 }
 
-// apiRenameTag is handler for PUT /api/tag
+// apiRenameTag is handler for PUT /api/tags
 func (h *handler) apiRenameTag(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
 	// Make sure session still valid
 	err := h.validateSession(r)

--- a/internal/webserver/handler-api.go
+++ b/internal/webserver/handler-api.go
@@ -213,8 +213,12 @@ func (h *handler) apiGetTags(w http.ResponseWriter, r *http.Request, ps httprout
 	tags, err := h.DB.GetTags()
 	checkError(err)
 
+	resp := map[string]interface{}{
+		"tags": tags,
+	}
+
 	w.Header().Set("Content-Type", "application/json")
-	err = json.NewEncoder(w).Encode(&tags)
+	err = json.NewEncoder(w).Encode(&resp)
 	checkError(err)
 }
 

--- a/internal/webserver/handler-api.go
+++ b/internal/webserver/handler-api.go
@@ -666,7 +666,7 @@ func (h *handler) apiUpdateAccount(w http.ResponseWriter, r *http.Request, ps ht
 		h.UserCache.Delete(request.Username)
 	}
 
-	fmt.Fprint(w, 1)
+	w.WriteHeader(http.StatusNoContent)
 }
 
 // apiDeleteAccount is handler for DELETE /api/accounts

--- a/internal/webserver/handler-api.go
+++ b/internal/webserver/handler-api.go
@@ -594,8 +594,12 @@ func (h *handler) apiGetAccounts(w http.ResponseWriter, r *http.Request, ps http
 	accounts, err := h.DB.GetAccounts(database.GetAccountsOptions{})
 	checkError(err)
 
+	resp := map[string]interface{}{
+		"accounts": accounts,
+	}
+
 	w.Header().Set("Content-Type", "application/json")
-	err = json.NewEncoder(w).Encode(&accounts)
+	err = json.NewEncoder(w).Encode(&resp)
 	checkError(err)
 }
 

--- a/internal/webserver/handler-api.go
+++ b/internal/webserver/handler-api.go
@@ -251,6 +251,10 @@ func (h *handler) apiInsertBookmark(w http.ResponseWriter, r *http.Request, ps h
 	err = json.NewDecoder(r.Body).Decode(&book)
 	checkError(err)
 
+	// Retain the user-supplied title and excerpt
+	userTitle := book.Title
+	userExcerpt := book.Excerpt
+
 	// Create bookmark ID
 	book.ID, err = h.DB.CreateNewID("bookmark")
 	if err != nil {
@@ -280,6 +284,14 @@ func (h *handler) apiInsertBookmark(w http.ResponseWriter, r *http.Request, ps h
 		if err != nil && isFatalErr {
 			panic(fmt.Errorf("failed to process bookmark: %v", err))
 		}
+	}
+
+	// Use the user-supplied title and excerpt if they exist
+	if userExcerpt != "" {
+		book.Excerpt = userExcerpt
+	}
+	if userTitle != "" {
+		book.Title = userTitle
 	}
 
 	// Save bookmark to database

--- a/internal/webserver/handler-api.go
+++ b/internal/webserver/handler-api.go
@@ -320,7 +320,7 @@ func (h *handler) apiDeleteBookmark(w http.ResponseWriter, r *http.Request, ps h
 		os.Remove(archivePath)
 	}
 
-	fmt.Fprint(w, 1)
+	w.WriteHeader(http.StatusNoContent)
 }
 
 // apiUpdateBookmark is handler for PUT /api/bookmarks
@@ -697,5 +697,5 @@ func (h *handler) apiDeleteAccount(w http.ResponseWriter, r *http.Request, ps ht
 		}
 	}
 
-	fmt.Fprint(w, 1)
+	w.WriteHeader(http.StatusNoContent)
 }

--- a/internal/webserver/server.go
+++ b/internal/webserver/server.go
@@ -46,7 +46,7 @@ func ServeApp(DB database.DB, dataDir string, address string, port int) error {
 	router.POST("/api/logout", hdl.apiLogout)
 	router.GET("/api/bookmarks", hdl.apiGetBookmarks)
 	router.GET("/api/tags", hdl.apiGetTags)
-	router.PUT("/api/tag", hdl.apiRenameTag)
+	router.PUT("/api/tags", hdl.apiRenameTag)
 	router.POST("/api/bookmarks", hdl.apiInsertBookmark)
 	router.DELETE("/api/bookmarks", hdl.apiDeleteBookmark)
 	router.PUT("/api/bookmarks", hdl.apiUpdateBookmark)

--- a/internal/webserver/server.go
+++ b/internal/webserver/server.go
@@ -1,6 +1,7 @@
 package webserver
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"time"
@@ -62,7 +63,13 @@ func ServeApp(DB database.DB, dataDir string, address string, port int) error {
 
 	// Route for panic
 	router.PanicHandler = func(w http.ResponseWriter, r *http.Request, arg interface{}) {
-		http.Error(w, fmt.Sprint(arg), 500)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusInternalServerError)
+
+		resp := map[string]interface{}{
+			"error": arg.(error).Error(),
+		}
+		_ = json.NewEncoder(w).Encode(&resp)
 	}
 
 	// Create server


### PR DESCRIPTION
This PR fixes an issue where the `title` and `excerpt` attributes provided in the `POST /api/bookmark` request were not being saved into the database. The handler now checks whether the user has provided their own `title` and `excerpt` values, and if so, replaces the ones fetched by `core.ProcessBookmark`.