### PR TITLE
wrap mime.TypeByExtension with preset mimetypes

### DIFF
--- a/internal/webserver/utils.go
+++ b/internal/webserver/utils.go
@@ -16,7 +16,26 @@ import (
 	"syscall"
 )
 
-var rxRepeatedStrip = regexp.MustCompile(`(?i)-+`)
+var (
+	rxRepeatedStrip = regexp.MustCompile(`(?i)-+`)
+
+	presetMimeTypes = map[string]string{
+		".css":  "text/css; charset=utf-8",
+		".html": "text/html; charset=utf-8",
+		".js":   "application/javascript",
+		".png":  "image/png",
+	}
+)
+
+func guessTypeByExtension(ext string) string {
+	ext = strings.ToLower(ext)
+
+	if v, ok := presetMimeTypes[ext]; ok {
+		return v
+	}
+
+	return mime.TypeByExtension(ext)
+}
 
 func serveFile(w http.ResponseWriter, filePath string, cache bool) error {
 	// Open file
@@ -42,7 +61,7 @@ func serveFile(w http.ResponseWriter, filePath string, cache bool) error {
 
 	// Set content type
 	ext := fp.Ext(filePath)
-	mimeType := mime.TypeByExtension(ext)
+	mimeType := guessTypeByExtension(ext)
 	if mimeType != "" {
 		w.Header().Set("Content-Type", mimeType)
 		w.Header().Set("X-Content-Type-Options", "nosniff")


### PR DESCRIPTION
Fixes #182 

Not quite sure if this is the best fix. But I looked at the files under `view` and they seem to be `.css`, `.html`, `.js`, `.png`. The corresponding mimetypes are preset in a `map[string]string` var.

This seems to only happen on Windows, as the mimetypes are extracted from the registry as per [Golang docs](https://golang.org/pkg/mime/#TypeByExtension)

If there's no preset mimetype, it calls `mime.TypeByExtension` under the hood.

If you believe there's a less obtrusive fix, please let me know!

Cheers!