### PR TITLE
Inherit user id/group for created directories and files

### DIFF
--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -59,6 +59,12 @@ func preRunRootHandler(cmd *cobra.Command, args []string) {
 		os.Exit(1)
 	}
 
+	err = os.Chown(dataDir, os.Getuid(), os.Getgid())
+	if err != nil {
+		cError.Printf("Failed to chown data dir: %v\n", err)
+		os.Exit(1)
+	}
+
 	// Open database
 	db, err = openDatabase()
 	if err != nil {

--- a/internal/core/processing.go
+++ b/internal/core/processing.go
@@ -157,11 +157,17 @@ func downloadBookImage(url, dstPath string) error {
 		return fmt.Errorf("%s is not a supported image", url)
 	}
 
+	finalDir := fp.Dir(dstPath)
 	// At this point, the download has finished successfully.
 	// Prepare destination file.
-	err = os.MkdirAll(fp.Dir(dstPath), os.ModePerm)
+	err = os.MkdirAll(finalDir, os.ModePerm)
 	if err != nil {
 		return fmt.Errorf("failed to create image dir: %v", err)
+	}
+
+	err = os.Chown(finalDir, os.Getuid(), os.Getgid())
+	if err != nil {
+		return fmt.Errorf("failed to chown image dir: %v", err)
 	}
 
 	dstFile, err := os.Create(dstPath)
@@ -169,6 +175,11 @@ func downloadBookImage(url, dstPath string) error {
 		return fmt.Errorf("failed to create image file: %v", err)
 	}
 	defer dstFile.Close()
+
+	err = dstFile.Chown(os.Getuid(), os.Getgid())
+	if err != nil {
+		return fmt.Errorf("failed to chown image file: %v", err)
+	}
 
 	// Parse image and process it.
 	// If image is smaller than 600x400 or its ratio is less than 4:3, resize.


### PR DESCRIPTION
I use shiori on my server in docker, but I prefer to lock down the shared mount to a user on the host server.
As it stands shiori just always creates everything under root so even if it's run under another user it doesn't play well in creating files/directories.

These changes are only in the core and in the initial data directory creation. I imagine there are some other parts of the code that could use this treatment for consistency as well, but I'm only using these portions so I only addressed these portions of the code.