### PR TITLE
[+] release for several platforms

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,31 @@
+name: Create release of shiori
+
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v2
+      -
+        name: Unshallow
+        run: git fetch --prune --unshallow
+      -
+        name: Set up Go
+        uses: actions/setup-go@v1
+        with:
+          go-version: 1.14.x
+      -
+        name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v1
+        with:
+          version: latest
+          args: release --rm-dist
+          key: ${{ secrets.YOUR_PRIVATE_KEY }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@
 
 # Exclude development data
 /dev-data
+
+# Exclude goreleaser output directory
+/dist

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,51 @@
+# This is an example goreleaser.yaml file with some sane defaults.
+# Make sure to check the documentation at http://goreleaser.com
+before:
+  hooks:
+    # You may remove this if you don't use go modules.
+    - go mod download
+    # you may remove this if you don't need go generate
+    # - go generate ./...
+builds:
+-
+  goos:
+    - linux
+    - darwin
+    - windows
+  goarch:
+    - 386
+    - amd64
+  ignore:
+    - goos: darwin
+      goarch: 386
+archives:
+  - name_template: '{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}'
+    replacements:
+      darwin: Darwin
+      linux: Linux
+      windows: Windows
+      386: i386
+      amd64: x86_64
+    format: zip
+release:
+  github:
+    owner: juev
+    name: shiori
+# dockers:
+#   - image_templates:
+#     - 'radhifadlillah/shiori:{{ .Tag }}'
+#     - 'radhifadlillah/shiori:v{{ .Major }}.{{ .Minor }}'
+#     - 'radhifadlillah/shiori:latest'
+#     dockerfile: Dockerfile
+#     binaries:
+#     - shiori
+checksum:
+  name_template: '{{ .ProjectName }}_checksums.txt'
+snapshot:
+  name_template: "{{ .Tag }}-next"
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - '^docs:'
+      - '^test:'


### PR DESCRIPTION
Hello,

I would like to provide configuration github actions for build shiori for several platforms.

It's used goreleaser for build and publish. I provide configuration for build docker container too, but I dont have rights for publishing, and I disable it now.

For this github action you shoud provide your github token in your secrets with name `TOKEN`.
If you cannot provide this variable build was broken.

Github Action is running whtn you create new release.

How this release it look like:
https://github.com/juev/shiori/releases/tag/v1.5.1