### PR TITLE
update url also when offline mode

### DIFF
--- a/internal/cmd/update.go
+++ b/internal/cmd/update.go
@@ -246,6 +246,11 @@ func updateHandler(cmd *cobra.Command, args []string) {
 			book.Excerpt = excerpt
 		}
 
+		// If user submits url, use it
+		if url != "" {
+			book.URL = url
+		}
+
 		// Make sure title is valid and not empty
 		book.Title = validateTitle(book.Title, book.URL)
 


### PR DESCRIPTION
When -o parameter was used, the url parameter was accepted but ignored and not updated at all.