### PR TITLE
Exit with non-zero status when commands fail

### DIFF
--- a/internal/cmd/check.go
+++ b/internal/cmd/check.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"net/http"
+	"os"
 	"sort"
 	"sync"
 	"time"
@@ -47,7 +48,7 @@ func checkHandler(cmd *cobra.Command, args []string) {
 	ids, err := parseStrIndices(args)
 	if err != nil {
 		cError.Printf("Failed to parse args: %v\n", err)
-		return
+		os.Exit(1)
 	}
 
 	// Fetch bookmarks from database
@@ -55,7 +56,7 @@ func checkHandler(cmd *cobra.Command, args []string) {
 	bookmarks, err := db.GetBookmarks(filterOptions)
 	if err != nil {
 		cError.Printf("Failed to get bookmarks: %v\n", err)
-		return
+		os.Exit(1)
 	}
 
 	// Create HTTP client
@@ -127,15 +128,17 @@ func checkHandler(cmd *cobra.Command, args []string) {
 	// Print the unreachable bookmarks
 	fmt.Println()
 
+	var code int
 	if len(unreachableIDs) == 0 {
-		cInfo.Println("All bookmarks is reachable.")
+		cInfo.Println("All bookmarks are reachable.")
 	} else {
 		sort.Ints(unreachableIDs)
-
+		code = 1
 		cError.Println("Encountered some unreachable bookmarks:")
 		for _, id := range unreachableIDs {
 			cError.Printf("%d ", id)
 		}
 		fmt.Println()
 	}
+	os.Exit(code)
 }

--- a/internal/cmd/delete.go
+++ b/internal/cmd/delete.go
@@ -48,14 +48,14 @@ func deleteHandler(cmd *cobra.Command, args []string) {
 	ids, err := parseStrIndices(args)
 	if err != nil {
 		cError.Printf("Failed to parse args: %v\n", err)
-		return
+		os.Exit(1)
 	}
 
 	// Delete bookmarks from database
 	err = db.DeleteBookmarks(ids...)
 	if err != nil {
 		cError.Printf("Failed to delete bookmarks: %v\n", err)
-		return
+		os.Exit(1)
 	}
 
 	// Delete thumbnail image and archives from local disk

--- a/internal/cmd/export.go
+++ b/internal/cmd/export.go
@@ -27,7 +27,7 @@ func exportHandler(cmd *cobra.Command, args []string) {
 	bookmarks, err := db.GetBookmarks(database.GetBookmarksOptions{})
 	if err != nil {
 		cError.Printf("Failed to get bookmarks: %v\n", err)
-		return
+		os.Exit(1)
 	}
 
 	if len(bookmarks) == 0 {
@@ -43,7 +43,7 @@ func exportHandler(cmd *cobra.Command, args []string) {
 	dstFile, err := os.Create(args[0])
 	if err != nil {
 		cError.Printf("Failed to create destination file: %v\n", err)
-		return
+		os.Exit(1)
 	}
 	defer dstFile.Close()
 
@@ -85,7 +85,7 @@ func exportHandler(cmd *cobra.Command, args []string) {
 	err = dstFile.Sync()
 	if err != nil {
 		cError.Printf("Failed to export the bookmarks: %v\n", err)
-		return
+		os.Exit(1)
 	}
 
 	fmt.Println("Export finished")

--- a/internal/cmd/import.go
+++ b/internal/cmd/import.go
@@ -41,14 +41,14 @@ func importHandler(cmd *cobra.Command, args []string) {
 	bookID, err := db.CreateNewID("bookmark")
 	if err != nil {
 		cError.Printf("Failed to create ID: %v\n", err)
-		return
+		os.Exit(1)
 	}
 
 	// Open bookmark's file
 	srcFile, err := os.Open(args[0])
 	if err != nil {
 		cError.Printf("Failed to open %s: %v\n", args[0], err)
-		return
+		os.Exit(1)
 	}
 	defer srcFile.Close()
 
@@ -59,7 +59,7 @@ func importHandler(cmd *cobra.Command, args []string) {
 	doc, err := goquery.NewDocumentFromReader(srcFile)
 	if err != nil {
 		cError.Printf("Failed to parse bookmark: %v\n", err)
-		return
+		os.Exit(1)
 	}
 
 	doc.Find("dt>a").Each(func(_ int, a *goquery.Selection) {
@@ -130,7 +130,7 @@ func importHandler(cmd *cobra.Command, args []string) {
 	bookmarks, err = db.SaveBookmarks(bookmarks...)
 	if err != nil {
 		cError.Printf("Failed to save bookmarks: %v\n", err)
-		return
+		os.Exit(1)
 	}
 
 	// Print imported bookmark

--- a/internal/cmd/pocket.go
+++ b/internal/cmd/pocket.go
@@ -36,7 +36,7 @@ func pocketHandler(cmd *cobra.Command, args []string) {
 	srcFile, err := os.Open(args[0])
 	if err != nil {
 		cError.Println(err)
-		return
+		os.Exit(1)
 	}
 	defer srcFile.Close()
 
@@ -47,7 +47,7 @@ func pocketHandler(cmd *cobra.Command, args []string) {
 	doc, err := goquery.NewDocumentFromReader(srcFile)
 	if err != nil {
 		cError.Println(err)
-		return
+		os.Exit(1)
 	}
 
 	doc.Find("a").Each(func(_ int, a *goquery.Selection) {
@@ -109,7 +109,7 @@ func pocketHandler(cmd *cobra.Command, args []string) {
 	bookmarks, err = db.SaveBookmarks(bookmarks...)
 	if err != nil {
 		cError.Printf("Failed to save bookmarks: %v\n", err)
-		return
+		os.Exit(1)
 	}
 
 	// Print imported bookmark

--- a/internal/cmd/print.go
+++ b/internal/cmd/print.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
+	"os"
 
 	"github.com/go-shiori/shiori/internal/database"
 	"github.com/spf13/cobra"
@@ -83,7 +84,7 @@ func printHandler(cmd *cobra.Command, args []string) {
 		bt, err := json.MarshalIndent(&bookmarks, "", "    ")
 		if err != nil {
 			cError.Println(err)
-			return
+			os.Exit(1)
 		}
 
 		fmt.Println(string(bt))

--- a/internal/cmd/update.go
+++ b/internal/cmd/update.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"os"
 	"sort"
 	"strings"
 	"sync"
@@ -67,7 +68,7 @@ func updateHandler(cmd *cobra.Command, args []string) {
 	ids, err := parseStrIndices(args)
 	if err != nil {
 		cError.Printf("Failed to parse args: %v\n", err)
-		return
+		os.Exit(1)
 	}
 
 	// Clean up new parameter from flags
@@ -84,7 +85,7 @@ func updateHandler(cmd *cobra.Command, args []string) {
 		// Since user uses custom URL, make sure there is only one ID to update
 		if len(ids) != 1 {
 			cError.Println("Update only accepts one index while using --url flag")
-			return
+			os.Exit(1)
 		}
 	}
 
@@ -96,12 +97,12 @@ func updateHandler(cmd *cobra.Command, args []string) {
 	bookmarks, err := db.GetBookmarks(filterOptions)
 	if err != nil {
 		cError.Printf("Failed to get bookmarks: %v\n", err)
-		return
+		os.Exit(1)
 	}
 
 	if len(bookmarks) == 0 {
 		cError.Println("No matching index found")
-		return
+		os.Exit(1)
 	}
 
 	// Check if user really want to batch update archive
@@ -282,14 +283,16 @@ func updateHandler(cmd *cobra.Command, args []string) {
 	bookmarks, err = db.SaveBookmarks(bookmarks...)
 	if err != nil {
 		cError.Printf("Failed to save bookmark: %v\n", err)
-		return
+		os.Exit(1)
 	}
 
 	// Print updated bookmarks
 	fmt.Println()
 	printBookmarks(bookmarks...)
 
+	var code int
 	if len(idWithProblems) > 0 {
+		code = 1
 		sort.Ints(idWithProblems)
 
 		cError.Println("Encountered error while downloading some bookmark(s):")
@@ -298,4 +301,5 @@ func updateHandler(cmd *cobra.Command, args []string) {
 		}
 		fmt.Println()
 	}
+	os.Exit(code)
 }


### PR DESCRIPTION
Replace `return` with `os.Exit(1)` as appropriate.