### PR TITLE
Change shiori to not run as ROOT user and create SHIORI user (with debug)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,14 @@
 FROM golang:alpine AS builder
-RUN apk add --no-cache build-base
+ENV LDFLAGS="-s -W"
+RUN apk add --no-cache build-base upx
 WORKDIR /src
 COPY . .
 RUN go build
-
+RUN upx --lzma /src/shiori
 # server image
-FROM golang:alpine
+FROM alpine:3.12
+# Keep us up-to-date and secure every build
+RUN apk update && apk upgrade
 COPY --from=builder /src/shiori /usr/local/bin/
 ENV SHIORI_DIR /srv/shiori/
 EXPOSE 8080


### PR DESCRIPTION
This pull incorporates previous 'working' pull, and adds some security to the docker image by running shiori as non-root user.