### PR TITLE
CI/CD and Dockerfile updates

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+.git*
+docs
+*.md
+Dockerfile
+LICENSE
+modd.conf
+.dockerignore

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -124,4 +124,4 @@ jobs:
           platforms: linux/amd64,linux/arm/v7,linux/arm64
           push: true
           tags: |
-            go-shiori/shiori:${{ steps.vars.outputs.sha_short }}
+            deanishe/shiori:${{ steps.vars.outputs.sha_short }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,56 +1,40 @@
-name: CI
+name: Release
 
 on:
   push:
-    branches: [ master ]
-  pull_request:
+    tags:
+      - '*'
 
 jobs:
-  lint:
-    name: Lint and Vet
+  createRelease:
     runs-on: ubuntu-latest
     steps:
-      - name: Install Go
-        uses: actions/setup-go@v2
-        with:
-          go-version: 1.x
-      - name: Check out code
-        uses: actions/checkout@v2
-      - name: Install golint
-        run: go get golang.org/x/lint/golint
-      - name: Lint Go source code
-        run: golint -set_exit_status ./...
-      - name: Vet Go source code
-        run: go vet ./...
-
-  test:
-    name: Unit tests
-    strategy:
-      matrix:
-        go-version: [1.12.x, 1.13.x, 1.14.x, 1.15.x]
-        platform: [ubuntu-latest, macos-latest, windows-latest]
-    runs-on: ${{ matrix.platform }}
-    steps:
-      - name: Install Go
-        uses: actions/setup-go@v2
-        with:
-          go-version: ${{ matrix.go-version }}
-      - name: Check out code
-        uses: actions/checkout@v2
-      - name: Fetch dependencies
+      - name: Get the tag
+        id: get_tag
         run: |
-          go get -v -t -d ./...
-      - name: Run unit tests
-        run: go test ./...
-
-      # - name: Codecov
-      #   if: ${{ matrix.go-version == '1.14.x' && matrix.platform == 'ubuntu-latest' }}
-      #   uses: codecov/codecov-action@v1
-      #   with:
-      #     file: coverage.out
+          echo ::set-output name=TAG::${GITHUB_REF/refs\/tags\//}  
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ steps.get_tag.outputs.TAG }}
+          release_name: Release ${{ steps.get_tag.outputs.TAG }}
+          draft: false
+          prerelease: false
+      - name: Create variable files
+        run: |
+          cat <<< ${{ steps.create_release.outputs.upload_url }} > releaseurl.txt
+          cat <<< ${{ steps.get_tag.outputs.TAG }} > tag.txt
+      - name: Upload variables
+        uses: actions/upload-artifact@v2
+        with:
+          name: vars
+          path: ./*.txt
 
   build:
-    needs: [test]
+    needs: [createRelease]
     strategy:
       matrix:
         include:
@@ -76,37 +60,63 @@ jobs:
             ext: .exe
           - descrip: osx-amd64
             os: macos-latest
-            
+
     runs-on: ${{ matrix.os }}
     steps:
       - name: Install cross compile chain
         if: matrix.os == 'ubuntu-latest'
-        run: sudo apt install ${{matrix.chain}}  
+        run: sudo apt install ${{matrix.chain}}
       - name: Install Go
         uses: actions/setup-go@v2
         with:
           go-version: 1.x
       - name: Check out code
         uses: actions/checkout@v2
+      - name: Get vars
+        uses: actions/download-artifact@v1
+        with:
+          name: vars
+      - shell: bash
+        id: var      
+        run: |
+          echo ::set-output name=TAG::`cat vars/tag.txt`
+          echo ::set-output name=RELEASEURL::`cat vars/releaseurl.txt`
       - name: Build
         run: |
           go generate ./...
-          ${{ matrix.envflags }} go build -o shiori-${{ matrix.descrip }}${{ matrix.ext }} -a ${{ matrix.goflags }} .
+          ${{ matrix.envflags }} go build -o shiori-${{ steps.var.outputs.TAG }}-${{ matrix.descrip }}${{ matrix.ext }} -a ${{ matrix.goflags }} .
       - name: Upload artifacts
         uses: actions/upload-artifact@v2
         with:
           path: shiori-*
+      - name: Upload Release Asset
+        id: upload-release-asset 
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.var.outputs.RELEASEURL }}
+          asset_path: ./shiori-${{ steps.var.outputs.TAG }}-${{ matrix.descrip }}${{ matrix.ext }}
+          asset_name: shiori-${{ steps.var.outputs.TAG }}-${{ matrix.descrip }}${{ matrix.ext }}
+          asset_content_type: application/octet-stream
 
   docker:
-    if: github.ref == 'refs/heads/master'
+    needs: [createRelease]
     runs-on: ubuntu-latest
-    needs: [test]
     steps:
+      - name: Get vars
+        uses: actions/download-artifact@v1
+        with:
+          name: vars
+      - shell: bash
+        id: var        
+        run: |
+          echo ::set-output name=TAG::`cat vars/tag.txt`
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Get SHA
-        id: vars
-        run: echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
+      - name: Get the tag
+        id: get_tag
+        run: echo ::set-output name=TAG::${GITHUB_REF/refs\/tags\//}
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
       - name: Set up Docker Buildx
@@ -124,4 +134,5 @@ jobs:
           platforms: linux/amd64,linux/arm/v7,linux/arm64
           push: true
           tags: |
-            go-shiori/shiori:${{ steps.vars.outputs.sha_short }}
+            go-shiori/shiori:latest
+            go-shiori/shiori:${{ steps.var.outputs.TAG }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -134,5 +134,5 @@ jobs:
           platforms: linux/amd64,linux/arm/v7,linux/arm64
           push: true
           tags: |
-            go-shiori/shiori:latest
-            go-shiori/shiori:${{ steps.var.outputs.TAG }}
+            deanishe/shiori:latest
+            deanishe/shiori:${{ steps.var.outputs.TAG }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,19 @@
 # build stage
-FROM golang:alpine AS builder
-RUN apk add --no-cache build-base
+FROM golang:1.15.2-alpine AS builder
+
 WORKDIR /src
+RUN apk --update add \
+	ca-certificates \
+	musl-dev \
+	gcc
 COPY . .
-RUN go build
+RUN go generate ./... && CGO_ENABLED=1 go build -a -ldflags '-linkmode external -extldflags "-static" -s -w' .
 
 # server image
-FROM golang:alpine
+FROM scratch
 COPY --from=builder /src/shiori /usr/local/bin/
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+
 ENV SHIORI_DIR /srv/shiori/
 EXPOSE 8080
 CMD ["/usr/local/bin/shiori", "serve"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,9 @@
 FROM golang:1.15.2-alpine AS builder
 
 WORKDIR /src
+RUN adduser \
+    --disabled-password \    
+    --uid 10001 shioriuser
 RUN apk --update add \
 	ca-certificates \
 	musl-dev \
@@ -11,9 +14,11 @@ RUN go generate ./... && CGO_ENABLED=1 go build -a -ldflags '-linkmode external 
 
 # server image
 FROM scratch
+COPY --from=builder /etc/passwd /etc/passwd
 COPY --from=builder /src/shiori /usr/local/bin/
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 
+USER shioriuser
 ENV SHIORI_DIR /srv/shiori/
 EXPOSE 8080
 CMD ["/usr/local/bin/shiori", "serve"]


### PR DESCRIPTION
- Dockerfile changes
  - Added .dockerignore so unneded files aren't copied over
  - Smaller docker image using scratch image
  - Binaries are statically linked and build with cgo so that they can run on a scratch image.
  - docker image does run as root (could be a security issue) this could be easily changed but may also be harder to setup for some
 
- Releases
  - When a tag is created github actions will create a release and upload binaries.
  - Binaries for linux and windows are statically linked and built with cgo, so they should have no dependencies.
  - Built with `-extldflags -s -w` flags for a smaller binary this strips dwarf tables used in debuggers and doesn't affect stack traces. 
    - Release Targets:
      - linux-amd64 (tested)
      - linux-arm64 (untested)
      - linux-armv7 (untested)
      - win-amd64 (tested)
      - darwin-amd64 (untested)
  - Docker files will be created and uploaded to docker hub.
  - Tagged latest and with tag
     - linux-amd64 (tested)
     - linux-arm64 (untested)
     - linux-armv7 (untested)

- Continous Integration
  - uses v1.x for latest version of golang
  - added go vet in linting stage
  - go build is run for all release targets as well(maintainers will have access to build artifacts).
  - added docker build and upload to docker hub for push to master, images tagged with commit sha1.

- A go-shiori account will need to be made on docker hub
- A personal access token will need to be created on docker hub
- The following gihub actions secrets will need to be set in github
    - DOCKER_HUB_USERNAME
    - DOCKER_HUB_ACCESS_TOKEN

-Examples:
https://github.com/n8225/shiori/actions
https://github.com/n8225/shiori/releases
https://hub.docker.com/r/nrew225/shiori

Related Issues: #263 #260

Closes #254 #267 #238 #273