### PR TITLE
Add support for search bar to search tags without "tag:"

### DIFF
--- a/internal/database/sqlite.go
+++ b/internal/database/sqlite.go
@@ -240,11 +240,19 @@ func (db *SQLiteDatabase) GetBookmarks(opts GetBookmarksOptions) ([]model.Bookma
 		query += ` AND (b.url LIKE ? OR b.excerpt LIKE ? OR b.id IN (
 			SELECT docid id 
 			FROM bookmark_content 
-			WHERE title MATCH ? OR content MATCH ?))`
+			WHERE title MATCH ? OR content MATCH ?)) OR
+			b.id IN (
+			SELECT bt.bookmark_id
+			FROM bookmark_tag bt
+			LEFT JOIN tag t ON bt.tag_id = t.id
+			WHERE t.name IN(?)
+			GROUP BY bt.bookmark_id
+			HAVING COUNT(bt.bookmark_id) = 1)`
 
 		args = append(args,
 			"%"+opts.Keyword+"%",
 			"%"+opts.Keyword+"%",
+			opts.Keyword,
 			opts.Keyword,
 			opts.Keyword)
 	}


### PR DESCRIPTION
It was not possible to search for a tag without the prefix "tag:".
For a better usage, it would be nice to search tags without the
prefix.
With the prefix, it only searches the tags, like before.