### PR TITLE
Optimize the size of the built image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+.git*
+docs
+*.md
+Dockerfile
+LICENSE
+modd.conf
+.dockerignore

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,17 @@
-# build stage
-FROM golang:alpine AS builder
-RUN apk add --no-cache build-base
+FROM golang:1.16.4-alpine AS builder
 WORKDIR /src
+RUN adduser --disabled-password --uid 10001 shioriuser
+RUN apk --update add ca-certificates musl-dev gcc
+COPY go.mod go.sum ./
+RUN go env -w GO111MODULE=on && go env -w  GOPROXY=https://goproxy.io,direct
 COPY . .
-RUN go build
+RUN go generate ./... && CGO_ENABLED=1 go build -a -ldflags '-linkmode external -extldflags "-static" -s -w' .
 
-# server image
-FROM golang:alpine
+FROM scratch
+COPY --from=builder /etc/passwd /etc/passwd
 COPY --from=builder /src/shiori /usr/local/bin/
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+USER shioriuser
 ENV SHIORI_DIR /srv/shiori/
 EXPOSE 8080
 CMD ["/usr/local/bin/shiori", "serve"]


### PR DESCRIPTION
Inspired by https://github.com/go-shiori/shiori/pull/278  , thanks @n8225

This PR only optimized the final docker image size, eg:

```
shiori                                        latest                           553f858e15cb   9 minutes ago    13.5MB
radhifadlillah/shiori                         latest                           69e24681b088   8 months ago     422MB
```
