### PR TITLE
Remove golang from final docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,13 @@
 # build stage
-FROM golang:alpine AS builder
+FROM ghcr.io/ghcri/golang:1.17-alpine3.15 AS builder
 RUN apk add --no-cache build-base
 WORKDIR /src
 COPY . .
 RUN go build
 
 # server image
-FROM golang:alpine
+LABEL org.opencontainers.image.source https://github.com/go-shiori/shiori
+FROM ghcr.io/ghcri/alpine:3.15
 COPY --from=builder /src/shiori /usr/local/bin/
 ENV SHIORI_DIR /srv/shiori/
 EXPOSE 8080


### PR DESCRIPTION
The current Dockerfile uses the golang:alpine image for the final image, which makes the final image much larger than needed.  This changes the final image to alpine and uses images from ghcr.io(It looks like these are ghcr.io official images pulled from dockerhub).  Also added a label to the image that will link the package to the repository.