### PR TITLE
feat: async content download when creating via api

### DIFF
--- a/internal/core/processing.go
+++ b/internal/core/processing.go
@@ -37,9 +37,9 @@ type ProcessRequest struct {
 }
 
 // ProcessBookmark process the bookmark and archive it if needed.
-// Return three values, the bookmark itself, is error fatal, and error value.
-func ProcessBookmark(req ProcessRequest) (model.Bookmark, bool, error) {
-	book := req.Bookmark
+// Return three values, is error fatal, and error value.
+func ProcessBookmark(req ProcessRequest) (book model.Bookmark, isFatalErr bool, err error) {
+	book = req.Bookmark
 	contentType := req.ContentType
 
 	// Make sure bookmark ID is defined
@@ -59,7 +59,7 @@ func ProcessBookmark(req ProcessRequest) (model.Bookmark, bool, error) {
 		multiWriter = io.MultiWriter(archivalInput, readabilityInput, readabilityCheckInput)
 	}
 
-	_, err := io.Copy(multiWriter, req.Content)
+	_, err = io.Copy(multiWriter, req.Content)
 	if err != nil {
 		return book, false, fmt.Errorf("failed to process article: %v", err)
 	}

--- a/internal/webserver/handler-api-ext.go
+++ b/internal/webserver/handler-api-ext.go
@@ -58,53 +58,51 @@ func (h *handler) apiInsertViaExtension(w http.ResponseWriter, r *http.Request, 
 		}
 	}
 
+	// Since we are using extension, the extension might send the HTML content
+	// so no need to download it again here. However, if it's empty, it might be not HTML file
+	// so we download it here.
+	var contentType string
+	var contentBuffer io.Reader
+
+	if book.HTML == "" {
+		contentBuffer, contentType, _ = core.DownloadBookmark(book.URL)
+	} else {
+		contentType = "text/html; charset=UTF-8"
+		contentBuffer = bytes.NewBufferString(book.HTML)
+	}
+
+	// At this point the web page already downloaded.
+	// Time to process it.
+	if contentBuffer != nil {
+		book.CreateArchive = true
+		request := core.ProcessRequest{
+			DataDir:     h.DataDir,
+			Bookmark:    book,
+			Content:     contentBuffer,
+			ContentType: contentType,
+		}
+
+		var isFatalErr bool
+		book, isFatalErr, err = core.ProcessBookmark(request)
+
+		if tmp, ok := contentBuffer.(io.ReadCloser); ok {
+			tmp.Close()
+		}
+
+		if err != nil && isFatalErr {
+			panic(fmt.Errorf("failed to process bookmark: %v", err))
+		}
+	}
+	if _, err := h.DB.SaveBookmarks(book); err != nil {
+		log.Printf("error saving bookmark after downloading content: %s", err)
+	}
+
 	// Save bookmark to database
 	results, err := h.DB.SaveBookmarks(book)
 	if err != nil || len(results) == 0 {
 		panic(fmt.Errorf("failed to save bookmark: %v", err))
 	}
 	book = results[0]
-
-	go func() {
-		// Since we are using extension, the extension might send the HTML content
-		// so no need to download it again here. However, if it's empty, it might be not HTML file
-		// so we download it here.
-		var contentType string
-		var contentBuffer io.Reader
-
-		if book.HTML == "" {
-			contentBuffer, contentType, _ = core.DownloadBookmark(book.URL)
-		} else {
-			contentType = "text/html; charset=UTF-8"
-			contentBuffer = bytes.NewBufferString(book.HTML)
-		}
-
-		// At this point the web page already downloaded.
-		// Time to process it.
-		if contentBuffer != nil {
-			book.CreateArchive = true
-			request := core.ProcessRequest{
-				DataDir:     h.DataDir,
-				Bookmark:    book,
-				Content:     contentBuffer,
-				ContentType: contentType,
-			}
-
-			var isFatalErr bool
-			book, isFatalErr, err = core.ProcessBookmark(request)
-
-			if tmp, ok := contentBuffer.(io.ReadCloser); ok {
-				tmp.Close()
-			}
-
-			if err != nil && isFatalErr {
-				panic(fmt.Errorf("failed to process bookmark: %v", err))
-			}
-		}
-		if _, err := h.DB.SaveBookmarks(book); err != nil {
-			log.Printf("error saving bookmark after downloading content: %s", err)
-		}
-	}()
 
 	// Return the new bookmark
 	w.Header().Set("Content-Type", "application/json")

--- a/internal/webserver/handler-api-ext.go
+++ b/internal/webserver/handler-api-ext.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log"
 	"net/http"
 	"os"
 	fp "path/filepath"
@@ -57,48 +58,53 @@ func (h *handler) apiInsertViaExtension(w http.ResponseWriter, r *http.Request, 
 		}
 	}
 
-	// Since we are using extension, the extension might send the HTML content
-	// so no need to download it again here. However, if it's empty, it might be not HTML file
-	// so we download it here.
-	var contentType string
-	var contentBuffer io.Reader
-
-	if book.HTML == "" {
-		contentBuffer, contentType, _ = core.DownloadBookmark(book.URL)
-	} else {
-		contentType = "text/html; charset=UTF-8"
-		contentBuffer = bytes.NewBufferString(book.HTML)
-	}
-
-	// At this point the web page already downloaded.
-	// Time to process it.
-	if contentBuffer != nil {
-		book.CreateArchive = true
-		request := core.ProcessRequest{
-			DataDir:     h.DataDir,
-			Bookmark:    book,
-			Content:     contentBuffer,
-			ContentType: contentType,
-		}
-
-		var isFatalErr bool
-		book, isFatalErr, err = core.ProcessBookmark(request)
-
-		if tmp, ok := contentBuffer.(io.ReadCloser); ok {
-			tmp.Close()
-		}
-
-		if err != nil && isFatalErr {
-			panic(fmt.Errorf("failed to process bookmark: %v", err))
-		}
-	}
-
 	// Save bookmark to database
 	results, err := h.DB.SaveBookmarks(book)
 	if err != nil || len(results) == 0 {
 		panic(fmt.Errorf("failed to save bookmark: %v", err))
 	}
 	book = results[0]
+
+	go func() {
+		// Since we are using extension, the extension might send the HTML content
+		// so no need to download it again here. However, if it's empty, it might be not HTML file
+		// so we download it here.
+		var contentType string
+		var contentBuffer io.Reader
+
+		if book.HTML == "" {
+			contentBuffer, contentType, _ = core.DownloadBookmark(book.URL)
+		} else {
+			contentType = "text/html; charset=UTF-8"
+			contentBuffer = bytes.NewBufferString(book.HTML)
+		}
+
+		// At this point the web page already downloaded.
+		// Time to process it.
+		if contentBuffer != nil {
+			book.CreateArchive = true
+			request := core.ProcessRequest{
+				DataDir:     h.DataDir,
+				Bookmark:    book,
+				Content:     contentBuffer,
+				ContentType: contentType,
+			}
+
+			var isFatalErr bool
+			book, isFatalErr, err = core.ProcessBookmark(request)
+
+			if tmp, ok := contentBuffer.(io.ReadCloser); ok {
+				tmp.Close()
+			}
+
+			if err != nil && isFatalErr {
+				panic(fmt.Errorf("failed to process bookmark: %v", err))
+			}
+		}
+		if _, err := h.DB.SaveBookmarks(book); err != nil {
+			log.Printf("error saving bookmark after downloading content: %s", err)
+		}
+	}()
 
 	// Return the new bookmark
 	w.Header().Set("Content-Type", "application/json")


### PR DESCRIPTION
Added an `async` field to POST /api/bookmark to allow the fetching of the bookmarks content to be asynchronous. The bookmarks updated content (thumbnail and so) will only be shown in the frontend after a refresh.

Along with that, the extension API call has been left untouched since I wasn't able to test it. We need to fix #269 before improving the webextension support.

Fixes: #302 
Blocked by: #367 