### PR TITLE
Remove unneeded alter table transactions from sqlite

### DIFF
--- a/internal/database/sqlite.go
+++ b/internal/database/sqlite.go
@@ -76,14 +76,6 @@ func OpenSQLiteDatabase(databasePath string) (sqliteDB *SQLiteDatabase, err erro
 	tx.MustExec(`CREATE VIRTUAL TABLE IF NOT EXISTS bookmark_content
 		USING fts5(title, content, html, docid)`)
 
-	// Alter table if needed
-	if _, err := tx.Exec(`ALTER TABLE account ADD COLUMN owner INTEGER NOT NULL DEFAULT 0`); err != nil {
-		log.Printf("error during database alert: %s", err)
-	}
-	if _, err := tx.Exec(`ALTER TABLE bookmark ADD COLUMN public INTEGER NOT NULL DEFAULT 0`); err != nil {
-		log.Printf("error during database alert: %s", err)
-	}
-
 	err = tx.Commit()
 	checkError(err)
 


### PR DESCRIPTION
Receive the following errors on startup after #367.
```
2022/02/14 11:23:42 error during database alert: SQL logic error: duplicate column name: owner (1)
2022/02/14 11:23:42 error during database alert: SQL logic error: duplicate column name: public (1)
```

Although these errors can be safely ignored since the columns exist, I think it would be safe to remove the alter table commands. The `owner` column was added to the `account` table in commit 0c4d75f77390ac2d2ba7a9436e2c2bc9b7102dd5 and the `public` column was added to the `bookmark` table in commit 20e89216f0b594e7aed231c5a31a71120d6ffba4 both over 2 years ago.  The only way I could see the removal being an issue is if the sqlite database was created before either of those commits and the tables haven't been updated by a later version. (In this case specify required migration path of current version in use -> v1.5.0 -> latest)

Alternatively, I believe we could use something along the lines of https://github.com/golang-migrate/migrate to ensure tables are setup correctly, might be beneficial in the future as well.