### PR TITLE
fix: trying to mkdir over an incorrect data path

### DIFF
--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -91,7 +91,7 @@ func getDataDir(portableMode bool) (string, error) {
 
 	// Try to use platform specific app path
 	userScope := apppaths.NewScope(apppaths.User, "shiori")
-	dataDir, err := userScope.DataPath("shiori.db")
+	dataDir, err := userScope.DataPath("")
 	if err == nil {
 		return dataDir, nil
 	}


### PR DESCRIPTION
The migration to the latest dependencies made a change on the library we use to retrieve data directories. In this case the path we were trying to get should be `~/.local/share/shiori/` and we were returning `~/.local/share/shiori/shiori.db` **as a path**, so users upgrading from 1.5.0 experienced an error when shiori tried to create that path hierarchy. This should fix that problem but we still need to address #377 to prevent problems for people migrating from 1.5.0.

Relates to #291 