### PR TITLE
sqlite: remove unneeded LEFT JOIN to improve performance

### DIFF
--- a/internal/database/sqlite.go
+++ b/internal/database/sqlite.go
@@ -213,6 +213,8 @@ func (db *SQLiteDatabase) SaveBookmarks(bookmarks ...model.Bookmark) (result []m
 
 // GetBookmarks fetch list of bookmarks based on submitted options.
 func (db *SQLiteDatabase) GetBookmarks(opts GetBookmarksOptions) ([]model.Bookmark, error) {
+	log.Printf("Start GetBookmarks...")
+
 	// Create initial query
 	columns := []string{
 		`b.id`,
@@ -221,16 +223,14 @@ func (db *SQLiteDatabase) GetBookmarks(opts GetBookmarksOptions) ([]model.Bookma
 		`b.excerpt`,
 		`b.author`,
 		`b.public`,
-		`b.modified`,
-		`bc.content <> "" has_content`}
+		`b.modified`}
 
 	if opts.WithContent {
-		columns = append(columns, `bc.content`, `bc.html`)
+		columns = append(columns)
 	}
 
 	query := `SELECT ` + strings.Join(columns, ",") + `
 		FROM bookmark b
-		LEFT JOIN bookmark_content bc ON bc.docid = b.id
 		WHERE 1`
 
 	// Add where clause
@@ -357,15 +357,18 @@ func (db *SQLiteDatabase) GetBookmarks(opts GetBookmarksOptions) ([]model.Bookma
 		bookmarks[i] = book
 	}
 
+	log.Printf("End GetBookmarks")
+
 	return bookmarks, nil
 }
 
 // GetBookmarksCount fetch count of bookmarks based on submitted options.
 func (db *SQLiteDatabase) GetBookmarksCount(opts GetBookmarksOptions) (int, error) {
+	log.Printf("Start GetBookmarksCount...")
+
 	// Create initial query
 	query := `SELECT COUNT(b.id)
 		FROM bookmark b
-		LEFT JOIN bookmark_content bc ON bc.docid = b.id
 		WHERE 1`
 
 	// Add where clause
@@ -455,6 +458,8 @@ func (db *SQLiteDatabase) GetBookmarksCount(opts GetBookmarksOptions) (int, erro
 	if err != nil && err != sql.ErrNoRows {
 		return 0, fmt.Errorf("failed to fetch count: %v", err)
 	}
+
+	log.Printf("End GetBookmarksCount")
 
 	return nBookmarks, nil
 }

--- a/internal/database/sqlite.go
+++ b/internal/database/sqlite.go
@@ -221,19 +221,17 @@ func (db *SQLiteDatabase) GetBookmarks(opts GetBookmarksOptions) ([]model.Bookma
 		`b.excerpt`,
 		`b.author`,
 		`b.public`,
-		`b.modified`}
-
-	joinClause := ""
+		`b.modified`,
+		`bc.content <> "" has_content`}
 
 	if opts.WithContent {
-		columns = append(columns, `bc.content <> "" has_content`, `bc.content`, `bc.html`)
-		joinClause = `LEFT JOIN bookmark_content bc ON bc.docid = b.id`
+		columns = append(columns, `bc.content`, `bc.html`)
 	}
 
 	query := `SELECT ` + strings.Join(columns, ",") + `
-		FROM bookmark b ` +
-		joinClause +
-		` WHERE 1`
+		FROM bookmark b
+		LEFT JOIN bookmark_content bc ON bc.docid = b.id
+		WHERE 1`
 
 	// Add where clause
 	args := []interface{}{}


### PR DESCRIPTION
I came across this project a few days ago on HackerNews and I like it very much. After using it a bit more during the last few days, I notice that the performance degrades quickly. With 1187 bookmarks (40 pages), running the shiori server (using sqlite db) on MacBook Pro (16-inch, 2019) 2.6 GHz 6-Core Intel Core i7 took around 10 seconds to load and similar amount of time to switch between pages.

I managed to track down the culprit - it's the `LEFT JOIN` statements in the `GetBookmarks` and `GetBookmarksCount` methods in the `sqlite.go` that cause the slowness.

I'm not very familiar with the code base yet but it looks like we don't need `LEFT JOIN` in those methods. Removing it helps improving performance dramatically.

Before:

```
INFO[0000] Serve shiori in :8050 /
WARN[0005] GET /api/bookmarks?keyword=&tags=&exclude=&page=1  proto=HTTP/1.1 remote="127.0.0.1:54846" reqlen=0 size=25 status=500
INFO[0007] GET /login?dst=http%3A%2F%2Flocalhost%3A8050%2F%23home  proto=HTTP/1.1 remote="127.0.0.1:54846" reqlen=0 size=4376 status=200
INFO[0010] POST /api/login                               proto=HTTP/1.1 remote="127.0.0.1:54846" reqlen=61 size=101 status=200
INFO[0010] GET /                                         proto=HTTP/1.1 remote="127.0.0.1:54846" reqlen=0 size=5659 status=200
2022/02/26 10:43:21 Start GetBookmarksCount...
2022/02/26 10:43:32 End GetBookmarksCount
2022/02/26 10:43:32 Start GetBookmarks...
2022/02/26 10:43:32 End GetBookmarks
INFO[0021] GET /api/bookmarks?keyword=&tags=&exclude=&page=1  proto=HTTP/1.1 remote="127.0.0.1:54846" reqlen=0 size=10997 status=200
INFO[0021] GET /api/tags                                 proto=HTTP/1.1 remote="127.0.0.1:54846" reqlen=0 size=4206 status=200
2022/02/26 10:43:52 Start GetBookmarksCount...
2022/02/26 10:44:02 End GetBookmarksCount
2022/02/26 10:44:02 Start GetBookmarks...
2022/02/26 10:44:02 End GetBookmarks
INFO[0051] GET /api/bookmarks?keyword=&tags=&exclude=&page=1  proto=HTTP/1.1 remote="127.0.0.1:55174" reqlen=0 size=10997 status=200
INFO[0051] GET /api/tags                                 proto=HTTP/1.1 remote="127.0.0.1:55174" reqlen=0 size=4206 status=200
2022/02/26 10:44:18 Start GetBookmarksCount...
2022/02/26 10:44:29 End GetBookmarksCount
2022/02/26 10:44:29 Start GetBookmarks...
2022/02/26 10:44:30 End GetBookmarks
INFO[0079] GET /api/bookmarks?keyword=&tags=&exclude=&page=2  proto=HTTP/1.1 remote="127.0.0.1:55419" reqlen=0 size=9959 status=200
2022/02/26 10:44:42 Start GetBookmarksCount...
2022/02/26 10:44:52 End GetBookmarksCount
2022/02/26 10:44:52 Start GetBookmarks...
2022/02/26 10:44:53 End GetBookmarks
INFO[0102] GET /api/bookmarks?keyword=&tags=&exclude=&page=3  proto=HTTP/1.1 remote="127.0.0.1:55629" reqlen=0 size=10289 status=200
```

After

```
INFO[0000] Serve shiori in :8050 /
WARN[0008] GET /                                         proto=HTTP/1.1 remote="127.0.0.1:56649" reqlen=0 size=49 status=301
INFO[0008] GET /login?dst=%2F                            proto=HTTP/1.1 remote="127.0.0.1:56649" reqlen=0 size=4376 status=200
INFO[0008] GET /css/fonts/source-sans-pro-v13-latin-200.woff2  proto=HTTP/1.1 remote="127.0.0.1:56649" reqlen=0 size=15824 status=200
INFO[0017] POST /api/login                               proto=HTTP/1.1 remote="127.0.0.1:56733" reqlen=61 size=101 status=200
INFO[0017] GET /                                         proto=HTTP/1.1 remote="127.0.0.1:56733" reqlen=0 size=5659 status=200
2022/02/26 10:46:47 Start GetBookmarksCount...
2022/02/26 10:46:47 End GetBookmarksCount
2022/02/26 10:46:47 Start GetBookmarks...
2022/02/26 10:46:47 End GetBookmarks
INFO[0017] GET /api/bookmarks?keyword=&tags=&exclude=&page=1  proto=HTTP/1.1 remote="127.0.0.1:56733" reqlen=0 size=10997 status=200
INFO[0017] GET /api/tags                                 proto=HTTP/1.1 remote="127.0.0.1:56733" reqlen=0 size=4206 status=200
2022/02/26 10:46:52 Start GetBookmarksCount...
2022/02/26 10:46:52 End GetBookmarksCount
2022/02/26 10:46:52 Start GetBookmarks...
2022/02/26 10:46:52 End GetBookmarks
INFO[0023] GET /api/bookmarks?keyword=&tags=&exclude=&page=1  proto=HTTP/1.1 remote="127.0.0.1:56733" reqlen=0 size=10997 status=200
INFO[0023] GET /api/tags                                 proto=HTTP/1.1 remote="127.0.0.1:56733" reqlen=0 size=4206 status=200
2022/02/26 10:47:02 Start GetBookmarksCount...
2022/02/26 10:47:02 End GetBookmarksCount
2022/02/26 10:47:02 Start GetBookmarks...
2022/02/26 10:47:02 End GetBookmarks
INFO[0033] GET /api/bookmarks?keyword=&tags=&exclude=&page=2  proto=HTTP/1.1 remote="127.0.0.1:56733" reqlen=0 size=9959 status=200
2022/02/26 10:47:09 Start GetBookmarksCount...
2022/02/26 10:47:09 End GetBookmarksCount
2022/02/26 10:47:09 Start GetBookmarks...
2022/02/26 10:47:09 End GetBookmarks
INFO[0039] GET /api/bookmarks?keyword=&tags=&exclude=&page=3  proto=HTTP/1.1 remote="127.0.0.1:56733" reqlen=0 size=10289 status=200
```
