### PR TITLE
Improve performance for sqlite queries

### DIFF
--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -57,7 +57,7 @@ type DB interface {
 	// DeleteBookmarks removes all record with matching ids from database.
 	DeleteBookmarks(ids ...int) error
 
-	// GetBookmark fetchs bookmark based on its ID or URL.
+	// GetBookmark fetches bookmark based on its ID or URL.
 	GetBookmark(id int, url string) (model.Bookmark, bool)
 
 	// SaveAccount saves new account in database

--- a/internal/database/migrations/sqlite/0002_denormalize_content.down.sql
+++ b/internal/database/migrations/sqlite/0002_denormalize_content.down.sql
@@ -1,0 +1,16 @@
+BEGIN TRANSACTION;
+CREATE TABLE IF NOT EXISTS bookmark_temp(
+    id INTEGER NOT NULL,
+    url TEXT NOT NULL,
+    title TEXT NOT NULL,
+    excerpt TEXT NOT NULL DEFAULT '',
+    author TEXT NOT NULL DEFAULT '',
+    public INTEGER NOT NULL DEFAULT 0,
+    modified TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT bookmark_PK PRIMARY KEY(id),
+    CONSTRAINT bookmark_url_UNIQUE UNIQUE(url)
+);
+INSERT INTO bookmark_temp SELECT id, url, title, excerpt, author, public, modified FROM bookmark;
+DROP TABLE bookmark;
+ALTER TABLE bookmark_temp RENAME TO bookmark;
+COMMIT;

--- a/internal/database/migrations/sqlite/0002_denormalize_content.down.sql
+++ b/internal/database/migrations/sqlite/0002_denormalize_content.down.sql
@@ -1,16 +1,3 @@
 BEGIN TRANSACTION;
-CREATE TABLE IF NOT EXISTS bookmark_temp(
-    id INTEGER NOT NULL,
-    url TEXT NOT NULL,
-    title TEXT NOT NULL,
-    excerpt TEXT NOT NULL DEFAULT '',
-    author TEXT NOT NULL DEFAULT '',
-    public INTEGER NOT NULL DEFAULT 0,
-    modified TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    CONSTRAINT bookmark_PK PRIMARY KEY(id),
-    CONSTRAINT bookmark_url_UNIQUE UNIQUE(url)
-);
-INSERT INTO bookmark_temp SELECT id, url, title, excerpt, author, public, modified FROM bookmark;
-DROP TABLE bookmark;
-ALTER TABLE bookmark_temp RENAME TO bookmark;
+ALTER TABLE bookmark DROP COLUMN has_content;
 COMMIT;

--- a/internal/database/migrations/sqlite/0002_denormalize_content.up.sql
+++ b/internal/database/migrations/sqlite/0002_denormalize_content.up.sql
@@ -1,0 +1,6 @@
+ALTER TABLE bookmark
+    ADD has_content BOOLEAN DEFAULT FALSE NOT NULL;
+
+UPDATE bookmark
+SET has_content = bc.has_content FROM (SELECT docid, content <> '' AS has_content FROM bookmark_content) AS bc
+WHERE bookmark.id = bc.docid;

--- a/internal/database/migrations/sqlite/0002_denormalize_content.up.sql
+++ b/internal/database/migrations/sqlite/0002_denormalize_content.up.sql
@@ -1,6 +1,8 @@
+BEGIN TRANSACTION;
 ALTER TABLE bookmark
     ADD has_content BOOLEAN DEFAULT FALSE NOT NULL;
 
 UPDATE bookmark
 SET has_content = bc.has_content FROM (SELECT docid, content <> '' AS has_content FROM bookmark_content) AS bc
 WHERE bookmark.id = bc.docid;
+COMMIT;

--- a/internal/database/sqlite.go
+++ b/internal/database/sqlite.go
@@ -325,7 +325,8 @@ func (db *SQLiteDatabase) GetBookmarks(opts GetBookmarksOptions) ([]model.Bookma
 		for _, content := range contents {
 			contentMap[content.ID] = content
 		}
-		for _, book := range bookmarks {
+		for i := range bookmarks[:] {
+			book := &bookmarks[i]
 			if bookmarkContent, found := contentMap[book.ID]; found {
 				book.Content = bookmarkContent.Content
 				book.HTML = bookmarkContent.HTML

--- a/internal/database/sqlite.go
+++ b/internal/database/sqlite.go
@@ -312,14 +312,13 @@ func (db *SQLiteDatabase) GetBookmarks(opts GetBookmarksOptions) ([]model.Bookma
 		for _, book := range bookmarks {
 			bookmarkIds = append(bookmarkIds, book.ID)
 		}
-
-		query, args, err := sqlx.In(`SELECT docid, content, html FROM bookmark_content WHERE docid IN (?)`, bookmarkIds)
-		query = db.Rebind(query)
+		contentQuery, args, err := sqlx.In(`SELECT docid, content, html FROM bookmark_content WHERE docid IN (?)`, bookmarkIds)
+		contentQuery = db.Rebind(contentQuery)
 		if err != nil {
 			return nil, fmt.Errorf("failed to expand query: %v", err)
 		}
 
-		err = db.Select(&contents, query, args...)
+		err = db.Select(&contents, contentQuery, args...)
 		if err != nil && err != sql.ErrNoRows {
 			return nil, fmt.Errorf("failed to fetch content for bookmarks (%v): %v", bookmarkIds, err)
 		}

--- a/internal/database/sqlite.go
+++ b/internal/database/sqlite.go
@@ -21,13 +21,13 @@ type SQLiteDatabase struct {
 	sqlx.DB
 }
 
-type BookmarkContent struct {
+type bookmarkContent struct {
 	ID      int    `db:"docid"`
 	Content string `db:"content"`
 	HTML    string `db:"html"`
 }
 
-type TagContent struct {
+type tagContent struct {
 	ID int `db:"bookmark_id"`
 	model.Tag
 }
@@ -316,8 +316,8 @@ func (db *SQLiteDatabase) GetBookmarks(opts GetBookmarksOptions) ([]model.Bookma
 	// If content needed, fetch it separately
 	// It's faster than join with virtual table
 	if opts.WithContent {
-		contents := make([]BookmarkContent, 0, len(bookmarks))
-		contentMap := make(map[int]BookmarkContent, len(bookmarks))
+		contents := make([]bookmarkContent, 0, len(bookmarks))
+		contentMap := make(map[int]bookmarkContent, len(bookmarks))
 
 		contentQuery, args, err := sqlx.In(`SELECT docid, content, html FROM bookmark_content WHERE docid IN (?)`, bookmarkIds)
 		contentQuery = db.Rebind(contentQuery)
@@ -345,7 +345,7 @@ func (db *SQLiteDatabase) GetBookmarks(opts GetBookmarksOptions) ([]model.Bookma
 	}
 
 	// Fetch tags for each bookmark
-	tags := make([]TagContent, 0, len(bookmarks))
+	tags := make([]tagContent, 0, len(bookmarks))
 	tagsMap := make(map[int][]model.Tag, len(bookmarks))
 
 	tagsQuery, tagArgs, err := sqlx.In(`SELECT bt.bookmark_id, t.id, t.name

--- a/internal/database/sqlite.go
+++ b/internal/database/sqlite.go
@@ -322,7 +322,7 @@ func (db *SQLiteDatabase) GetBookmarks(opts GetBookmarksOptions) ([]model.Bookma
 		contentQuery, args, err := sqlx.In(`SELECT docid, content, html FROM bookmark_content WHERE docid IN (?)`, bookmarkIds)
 		contentQuery = db.Rebind(contentQuery)
 		if err != nil {
-			return nil, fmt.Errorf("failed to expand query: %v", err)
+			return nil, fmt.Errorf("failed to expand bookmark_content query: %v", err)
 		}
 
 		err = db.Select(&contents, contentQuery, args...)
@@ -355,7 +355,7 @@ func (db *SQLiteDatabase) GetBookmarks(opts GetBookmarksOptions) ([]model.Bookma
 		ORDER BY t.name`, bookmarkIds)
 	tagsQuery = db.Rebind(tagsQuery)
 	if err != nil {
-		return nil, fmt.Errorf("failed to expand query: %v", err)
+		return nil, fmt.Errorf("failed to expand bookmark_tag query: %v", err)
 	}
 
 	err = db.Select(&tags, tagsQuery, tagArgs...)

--- a/internal/database/sqlite.go
+++ b/internal/database/sqlite.go
@@ -124,7 +124,7 @@ func (db *SQLiteDatabase) SaveBookmarks(bookmarks ...model.Bookmark) (result []m
 			book.URL, book.Title, book.Excerpt, book.Author, book.Public, book.Modified)
 
 		// Try to update it first to check for existence, we can't do an UPSERT here because
-		// bookmant_content is a virtual table
+		// bookmark_content is a virtual table
 		res := stmtUpdateBookContent.MustExec(book.Title, book.Content, book.HTML, book.ID)
 		rows, _ := res.RowsAffected()
 		if rows == 0 {
@@ -476,7 +476,7 @@ func (db *SQLiteDatabase) DeleteBookmarks(ids ...int) (err error) {
 	return err
 }
 
-// GetBookmark fetchs bookmark based on its ID or URL.
+// GetBookmark fetches bookmark based on its ID or URL.
 // Returns the bookmark and boolean whether it's exist or not.
 func (db *SQLiteDatabase) GetBookmark(id int, url string) (model.Bookmark, bool) {
 	args := []interface{}{id}

--- a/internal/database/sqlite.go
+++ b/internal/database/sqlite.go
@@ -78,11 +78,11 @@ func (db *SQLiteDatabase) SaveBookmarks(bookmarks ...model.Bookmark) (result []m
 
 	// Prepare statement
 	stmtInsertBook, _ := tx.Preparex(`INSERT INTO bookmark
-		(id, url, title, excerpt, author, public, modified)
-		VALUES(?, ?, ?, ?, ?, ?, ?)
+		(id, url, title, excerpt, author, public, modified, has_content)
+		VALUES(?, ?, ?, ?, ?, ?, ?, ?)
 		ON CONFLICT(id) DO UPDATE SET
 		url = ?, title = ?,	excerpt = ?, author = ?,
-		public = ?, modified = ?`)
+		public = ?, modified = ?, has_content = ?`)
 
 	stmtInsertBookContent, _ := tx.Preparex(`INSERT OR REPLACE INTO bookmark_content
 		(docid, title, content, html)
@@ -125,9 +125,10 @@ func (db *SQLiteDatabase) SaveBookmarks(bookmarks ...model.Bookmark) (result []m
 		book.Modified = modifiedTime
 
 		// Save bookmark
+		hasContent := book.Content != ""
 		stmtInsertBook.MustExec(book.ID,
-			book.URL, book.Title, book.Excerpt, book.Author, book.Public, book.Modified,
-			book.URL, book.Title, book.Excerpt, book.Author, book.Public, book.Modified)
+			book.URL, book.Title, book.Excerpt, book.Author, book.Public, book.Modified, hasContent,
+			book.URL, book.Title, book.Excerpt, book.Author, book.Public, book.Modified, hasContent)
 
 		// Try to update it first to check for existence, we can't do an UPSERT here because
 		// bookmark_content is a virtual table

--- a/internal/webserver/server.go
+++ b/internal/webserver/server.go
@@ -83,7 +83,7 @@ func (r *loggingResponseWriter) WriteHeader(statusCode int) {
 	r.responseData.status = statusCode       // capture status code
 }
 
-// Log through logrus, 200 will log as info, anything else as an error.
+// Logger Log through logrus, 200 will log as info, anything else as an error.
 func Logger(r *http.Request, statusCode int, size int) {
 	if statusCode == http.StatusOK {
 		logrus.WithFields(logrus.Fields{


### PR DESCRIPTION
This PR is intended to address a range of performance regressions for the SQLite database.

Namely:
- Removed the slow JOIN for bookmark lists
- Reduced the number of queries for tags

Tested manually on 3k bookmarks with content. Last version ([7394b10](https://github.com/go-shiori/shiori/commit/7394b10)) returned main page in a second or two. Now it takes few, maybe tens of *milliseconds*.

Note that migration is required: `shiori migrate`.

Built an image for the test, now I use it myself: `docker.io/orhideous/go-shiori:1.5.2-perf-fix`

_P.S. There is definitely a room for improvement for another databases._

Fixes #408