### PR TITLE
fix: amd64 build paths

### DIFF
--- a/.github/workflows/_buildx.yml
+++ b/.github/workflows/_buildx.yml
@@ -20,6 +20,9 @@ jobs:
           mkdir binaries
           cp -r ../../../shiori_linux_* binaries/
           mv binaries/shiori_linux_arm_7 binaries/shiori_linux_arm
+          mv binaries/shiori_windows_amd64_v1 binaries/shiori_windows_amd64
+          mv binaries/shiori_darwin_amd64_v1 binaries/shiori_darwin_amd64
+          mv binaries/shiori_linux_amd64_v1 binaries/shiori_linux_amd64
           gzip -d -S binaries/.gz__  -r .
           chmod 755 binaries/shiori_linux_*/shiori
       - name: Buildx


### PR DESCRIPTION
The build paths for amd64 binaries changed to `amd64_v1` and caused buildx to fail. I'm fixing this by moving the path to the ones expected by buildx.