### PR TITLE
feat: session expire time from backend

### DIFF
--- a/internal/view/login.html
+++ b/internal/view/login.html
@@ -104,10 +104,10 @@
 						if (!response.ok) throw response;
 						return response.json();
 					}).then(json => {
+						console.log(json)
+
 						// Save session id
-						var sessionAge = this.remember == 1 ? 60 * 60 * 24 * 30 : 60 * 60
-						var expTime = new Date(Date.now() + sessionAge * 1000).toUTCString();
-						document.cookie = `session-id=${json.session}; Path=${new URL(document.baseURI).pathname}; Expires=${expTime}`;
+						document.cookie = `session-id=${json.session}; Path=${new URL(document.baseURI).pathname}; Expires=${json.expires}`;
 
 						// Save account data
 						localStorage.setItem("shiori-account", JSON.stringify(json.account));

--- a/internal/view/login.html
+++ b/internal/view/login.html
@@ -104,8 +104,6 @@
 						if (!response.ok) throw response;
 						return response.json();
 					}).then(json => {
-						console.log(json)
-
 						// Save session id
 						document.cookie = `session-id=${json.session}; Path=${new URL(document.baseURI).pathname}; Expires=${json.expires}`;
 

--- a/internal/webserver/handler-api.go
+++ b/internal/webserver/handler-api.go
@@ -82,7 +82,8 @@ func (h *handler) apiLogin(w http.ResponseWriter, r *http.Request, ps httprouter
 		loginResult := struct {
 			Session string        `json:"session"`
 			Account model.Account `json:"account"`
-		}{strSessionID, account}
+			Expires string        `json:"expires"`
+		}{strSessionID, account, time.Now().Add(expTime).Format(time.RFC1123)}
 
 		w.Header().Set("Content-Type", "application/json")
 		err = json.NewEncoder(w).Encode(&loginResult)


### PR DESCRIPTION
Deduplicated logic from backend and frontend where we needed to take the
login checkbox into account for both back and front codebases. Now the
backend will send the frontend the expire time calculated only in one
place.

This is part of a multi-step process that will store sessions in
database, but this will ease the maintenance of this section for now.