### PR TITLE
fix invalid assets path when use webroot

### DIFF
--- a/internal/webserver/handler-ui.go
+++ b/internal/webserver/handler-ui.go
@@ -14,9 +14,10 @@ import (
 	"strings"
 
 	"github.com/PuerkitoBio/goquery"
-	"github.com/go-shiori/shiori/internal/model"
 	"github.com/go-shiori/warc"
 	"github.com/julienschmidt/httprouter"
+
+	"github.com/go-shiori/shiori/internal/model"
 )
 
 // serveFile is handler for general file request
@@ -24,6 +25,7 @@ func (h *handler) serveFile(w http.ResponseWriter, r *http.Request, ps httproute
 	rootPath := strings.Trim(h.RootPath, "/")
 	urlPath := strings.Trim(r.URL.Path, "/")
 	filePath := strings.TrimPrefix(urlPath, rootPath)
+	filePath = strings.Trim(filePath, "/")
 
 	err := serveFile(w, filePath, true)
 	checkError(err)


### PR DESCRIPTION
fix https://github.com/go-shiori/shiori/issues/445

last time I used embed.Fs to replace the assets generation, it turns out that the sub path is difference. For exmaple, When using assets generation, the `css` assets would be at `/css`, and when using embed.Fs it must be `css` since the embed.Fs doesn't allow sub path start with `/`: https://github.com/golang/go/blob/master/src/io/fs/fs.go#L41