### PR TITLE
Fix docker migration script example

### DIFF
--- a/docs/Usage.md
+++ b/docs/Usage.md
@@ -49,8 +49,7 @@ If this is a fresh install or you're upgrading versions, you'll need to migrate 
 changes for Shiori to work properly:
 
 - If you're using the binary version: `shiori migrate`
-- If you're running the containerized version: `docker run containername shiori migrate` (you can also start a shell on the running container and perform the migration there).
-  - Remember to change `containername` with the name you gave to your container.
+- If you're running the containerized version: `docker run --rm -v $(pwd):/shiori ghcr.io/go-shiori/shiori migrate` (you can also start a shell on the running container and perform the migration there).
 
 ## Using Command Line Interface
 


### PR DESCRIPTION
The example docker command given was invalid, as `docker run` operates on images, not containers. This is the closest working alternative using the same command, with another option being `docker exec containername shiori migrate` to operate on an existing container.