### PR TITLE
fixbug: the bookmark Primary key also auto increment when insert false.

### DIFF
--- a/internal/database/pg.go
+++ b/internal/database/pg.go
@@ -75,6 +75,9 @@ func (db *PGDatabase) SaveBookmarks(bookmarks ...model.Bookmark) (result []model
 	}()
 
 	// Prepare statement
+	stmtGetBookmarkId, err := tx.Preparex(`SELECT id FROM bookmark WHERE url = $1`)
+	checkError(err)
+
 	stmtInsertBook, err := tx.Preparex(`INSERT INTO bookmark
 		(url, title, excerpt, author, public, content, html, modified)
 		VALUES($1, $2, $3, $4, $5, $6, $7, $8)
@@ -129,7 +132,9 @@ func (db *PGDatabase) SaveBookmarks(bookmarks ...model.Bookmark) (result []model
 		stmtInsertBook.MustExec(
 			book.URL, book.Title, book.Excerpt, book.Author,
 			book.Public, book.Content, book.HTML, book.Modified)
-
+		// get bookmark id
+		err = stmtGetBookmarkId.Get(&book.ID, book.URL)
+		checkError(err)
 		// Save book tags
 		newTags := []model.Tag{}
 		for _, tag := range book.Tags {


### PR DESCRIPTION
fixbug: the bookmark Primary key also auto increment when insert false.so after upsert or insert, we need get the right bookmark id with the url. so you are not sure the bookmark id before you insert sucessfully into bookmark table. you shoud get the id after insert sucessfully