### PR TITLE
fix: remove manual transaction on sqlite migration 2

### DIFF
--- a/internal/database/migrations/sqlite/0002_denormalize_content.down.sql
+++ b/internal/database/migrations/sqlite/0002_denormalize_content.down.sql
@@ -1,3 +1,1 @@
-BEGIN TRANSACTION;
 ALTER TABLE bookmark DROP COLUMN has_content;
-COMMIT;

--- a/internal/database/migrations/sqlite/0002_denormalize_content.up.sql
+++ b/internal/database/migrations/sqlite/0002_denormalize_content.up.sql
@@ -1,8 +1,6 @@
-BEGIN TRANSACTION;
 ALTER TABLE bookmark
     ADD has_content BOOLEAN DEFAULT FALSE NOT NULL;
 
 UPDATE bookmark
 SET has_content = bc.has_content FROM (SELECT docid, content <> '' AS has_content FROM bookmark_content) AS bc
 WHERE bookmark.id = bc.docid;
-COMMIT;


### PR DESCRIPTION
Fixes #465 