### PR TITLE
docs: fix remember represented as a number instead of a bool

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -35,7 +35,7 @@ Body:
 {
 	"username": "shiori",
 	"password": "gopher",
-	"remember": 1,
+	"remember": true,
 	"owner": true
 }
 ```

--- a/docs/postman/shiori.postman_collection.json
+++ b/docs/postman/shiori.postman_collection.json
@@ -22,7 +22,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n\t\"username\": \"shiori\",\n\t\"password\": \"gopher\",\n\t\"remember\": 1,\n\t\"owner\": true\n}"
+							"raw": "{\n\t\"username\": \"shiori\",\n\t\"password\": \"gopher\",\n\t\"remember\": true,\n\t\"owner\": true\n}"
 						},
 						"url": {
 							"raw": "{{host}}/api/login",


### PR DESCRIPTION
Changed in pull request: https://github.com/go-shiori/shiori/pull/346

Since the API does not support numbers for the `remember` field in `/api/login`, I changed the documentation to make it a boolean instead of a number.