### PR TITLE
Fix bug when add new bookmark using PostgreSQL

### DIFF
--- a/internal/database/pg.go
+++ b/internal/database/pg.go
@@ -607,7 +607,7 @@ func (db *PGDatabase) RenameTag(id int, newName string) error {
 // CreateNewID creates new ID for specified table
 func (db *PGDatabase) CreateNewID(table string) (int, error) {
 	var tableID int
-	query := fmt.Sprintf(`SELECT last_value from %s_id_seq;`, table)
+	query := fmt.Sprintf(`SELECT last_value + 1 from %s_id_seq;`, table)
 
 	err := db.Get(&tableID, query)
 	if err != nil && err != sql.ErrNoRows {

--- a/internal/database/pg.go
+++ b/internal/database/pg.go
@@ -607,7 +607,7 @@ func (db *PGDatabase) RenameTag(id int, newName string) error {
 // CreateNewID creates new ID for specified table
 func (db *PGDatabase) CreateNewID(table string) (int, error) {
 	var tableID int
-	query := fmt.Sprintf(`SELECT last_value + 1 from %s_id_seq;`, table)
+	query := fmt.Sprintf(`SELECT case when is_called then last_value + 1 else last_value end from %s_id_seq;`, table)
 
 	err := db.Get(&tableID, query)
 	if err != nil && err != sql.ErrNoRows {


### PR DESCRIPTION
Fixed a bug pages not archived although createArchive checkbox checked. (fix: https://github.com/go-shiori/shiori/issues/385) 

Maybe it is only occurred using postgres.
To be precise, the archive is saved, but the ID to refer to different.

This ploblem reason is diffrent create file path id(archive and thumb) and create bookmark record id.

Function of CreatNewID return recently numbered bookmark id that is not same to be insert bookmark record id.
Returned bookmark id is used to path of save thumb and archive.
But, record inserted by next numbered id.
As a result, New bookmark record try to refered  not exists directory pathes. 

This fix will be changes CreateNewID returned to be next numbered bookmark record id.

Excuse, This implements is not think about concurrency bookmarking.
But, Current implement is same about this point.