### PR TITLE
Draft: Use GORM to maintain multi-database layer

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,8 @@ require (
 	golang.org/x/crypto v0.0.0-20220722155217-630584e8d5aa
 	golang.org/x/net v0.0.0-20220425223048-2871e0cb64e4
 	golang.org/x/term v0.0.0-20220722155259-a9ba230a4035
+	gorm.io/driver/sqlite v1.3.6
+	gorm.io/gorm v1.23.4
 	modernc.org/sqlite v1.18.1
 )
 
@@ -35,9 +37,12 @@ require (
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
+	github.com/jinzhu/inflection v1.0.0 // indirect
+	github.com/jinzhu/now v1.1.5 // indirect
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 // indirect
 	github.com/mattn/go-colorable v0.1.12 // indirect
 	github.com/mattn/go-isatty v0.0.14 // indirect
+	github.com/mattn/go-sqlite3 v1.14.14 // indirect
 	github.com/mitchellh/go-homedir v1.1.0 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20200410134404-eec4a21b6bb0 // indirect
 	github.com/shurcooL/httpfs v0.0.0-20190707220628-8d4bc4ba7749 // indirect

--- a/go.sum
+++ b/go.sum
@@ -718,8 +718,12 @@ github.com/jackc/puddle v0.0.0-20190608224051-11cab39313c9/go.mod h1:m4B5Dj62Y0f
 github.com/jackc/puddle v1.1.0/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dvjSWk=
 github.com/jackc/puddle v1.1.1/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dvjSWk=
 github.com/jackc/puddle v1.1.3/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dvjSWk=
+github.com/jinzhu/inflection v1.0.0 h1:K317FqzuhWc8YvSVlFMCCUb36O/S9MCKRDI7QkRKD/E=
 github.com/jinzhu/inflection v1.0.0/go.mod h1:h+uFLlag+Qp1Va5pdKtLDYj+kHp5pxUVkryuEj+Srlc=
 github.com/jinzhu/now v1.1.1/go.mod h1:d3SSVoowX0Lcu0IBviAWJpolVfI5UJVZZ7cO71lE/z8=
+github.com/jinzhu/now v1.1.4/go.mod h1:d3SSVoowX0Lcu0IBviAWJpolVfI5UJVZZ7cO71lE/z8=
+github.com/jinzhu/now v1.1.5 h1:/o9tlHleP7gOFmsnYNz3RGnqzefHA47wQpKrrdTIwXQ=
+github.com/jinzhu/now v1.1.5/go.mod h1:d3SSVoowX0Lcu0IBviAWJpolVfI5UJVZZ7cO71lE/z8=
 github.com/jmespath/go-jmespath v0.0.0-20160202185014-0b12d6b521d8/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/jmespath/go-jmespath v0.0.0-20160803190731-bd40a432e4c7/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
@@ -824,7 +828,9 @@ github.com/mattn/go-shellwords v1.0.12/go.mod h1:EZzvwXDESEeg03EKmM+RmDnNOPKG4lL
 github.com/mattn/go-sqlite3 v1.9.0/go.mod h1:FPy6KqzDD04eiIsT53CuJW3U88zkxoIYsOqkbpncsNc=
 github.com/mattn/go-sqlite3 v1.14.6/go.mod h1:NyWgC/yNuGj7Q9rpYnZvas74GogHl5/Z4A/KQRfk6bU=
 github.com/mattn/go-sqlite3 v1.14.10/go.mod h1:NyWgC/yNuGj7Q9rpYnZvas74GogHl5/Z4A/KQRfk6bU=
+github.com/mattn/go-sqlite3 v1.14.12/go.mod h1:NyWgC/yNuGj7Q9rpYnZvas74GogHl5/Z4A/KQRfk6bU=
 github.com/mattn/go-sqlite3 v1.14.14 h1:qZgc/Rwetq+MtyE18WhzjokPD93dNqLGNT3QJuLvBGw=
+github.com/mattn/go-sqlite3 v1.14.14/go.mod h1:NyWgC/yNuGj7Q9rpYnZvas74GogHl5/Z4A/KQRfk6bU=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369/go.mod h1:BSXmuO+STAnVfrANrmjBb36TMTDstsz7MSK+HVaYKv4=
 github.com/maxbrunsfeld/counterfeiter/v6 v6.2.2/go.mod h1:eD9eIE7cdwcMi9rYluz88Jz2VyhSmden33/aXg4oVIY=
@@ -1801,8 +1807,12 @@ gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776/go.mod h1:K4uyk7z7BCEPqu6E+C
 gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b h1:h8qDotaEPuJATrMmW04NCwg7v22aHH28wwpauUhK9Oo=
 gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gorm.io/driver/postgres v1.0.8/go.mod h1:4eOzrI1MUfm6ObJU/UcmbXyiHSs8jSwH95G5P5dxcAg=
+gorm.io/driver/sqlite v1.3.6 h1:Fi8xNYCUplOqWiPa3/GuCeowRNBRGTf62DEmhMDHeQQ=
+gorm.io/driver/sqlite v1.3.6/go.mod h1:Sg1/pvnKtbQ7jLXxfZa+jSHvoX8hoZA8cn4xllOMTgE=
 gorm.io/gorm v1.20.12/go.mod h1:0HFTzE/SqkGTzK6TlDPPQbAYCluiVvhzoA1+aVyzenw=
 gorm.io/gorm v1.21.4/go.mod h1:0HFTzE/SqkGTzK6TlDPPQbAYCluiVvhzoA1+aVyzenw=
+gorm.io/gorm v1.23.4 h1:1BKWM67O6CflSLcwGQR7ccfmC4ebOxQrTfOQGRE9wjg=
+gorm.io/gorm v1.23.4/go.mod h1:l2lP/RyAtc1ynaTjFksBde/O8v9oOGIApu2/xRitmZk=
 gotest.tools v2.2.0+incompatible/go.mod h1:DsYFclhRJ6vuDpmuTbkuFWG+y2sxOXAzmJt81HFBacw=
 gotest.tools/v3 v3.0.2/go.mod h1:3SzNCllyD9/Y+b5r9JIKQ474KzkZyqLqEfYqMsX94Bk=
 gotest.tools/v3 v3.0.3/go.mod h1:Z7Lb0S5l+klDB31fvDQX8ss/FlKDxtlFlw3Oa8Ymbl8=

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -108,9 +108,15 @@ func openDatabase(ctx context.Context) (database.DB, error) {
 		return openMySQLDatabase(ctx)
 	case "postgresql":
 		return openPostgreSQLDatabase(ctx)
+	case "gorm":
+		return openGormDatabase(ctx)
 	default:
 		return openSQLiteDatabase(ctx)
 	}
+}
+
+func openGormDatabase(ctx context.Context) (database.DB, error) {
+	return database.OpenGORMDatabase(ctx, fp.Join(dataDir, "shiori.db"))
 }
 
 func openSQLiteDatabase(ctx context.Context) (database.DB, error) {

--- a/internal/database/sqlite_gorm.go
+++ b/internal/database/sqlite_gorm.go
@@ -1,0 +1,117 @@
+package database
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"github.com/go-shiori/shiori/internal/model"
+	"gorm.io/gorm"
+
+	"gorm.io/driver/sqlite"
+)
+
+// GormDatabase is implementation of Database interface
+// for connecting to Gorm generated databases.
+type GormDatabase struct {
+	dbbase
+
+	gorm *gorm.DB
+}
+
+// OpenGORMDatabase creates and open connection
+func OpenGORMDatabase(ctx context.Context, databasePath string) (gormdb *GormDatabase, err error) {
+	db, _ := gorm.Open(sqlite.Open(databasePath))
+	gormdb = &GormDatabase{
+		gorm: db,
+	}
+
+	return gormdb, gormdb.Migrate()
+}
+
+// Migrate runs migrations for this database engine
+func (db *GormDatabase) Migrate() error {
+	if err := db.gorm.AutoMigrate(&model.Account{}); err != nil {
+		log.Fatal(err)
+		return fmt.Errorf("error migrating account table: %s", err)
+	}
+
+	// if err := db.gorm.AutoMigrate(&model.Bookmark{}); err != nil {
+	// 	log.Fatal(err)
+	// 	return fmt.Errorf("error migrating bookmark table: %s", err)
+	// }
+
+	// if err := db.gorm.AutoMigrate(&model.Tag{}); err != nil {
+	// 	log.Fatal(err)
+	// 	return fmt.Errorf("error migrating tag table: %s", err)
+	// }
+
+	return nil
+}
+
+// SaveBookmarks saves new or updated bookmarks to database.
+// Returns the saved ID and error message if any happened.
+func (db *GormDatabase) SaveBookmarks(ctx context.Context, bookmarks ...model.Bookmark) (result []model.Bookmark, err error) {
+	return
+}
+
+// GetBookmarks fetch list of bookmarks based on submitted options.
+func (db *GormDatabase) GetBookmarks(ctx context.Context, opts GetBookmarksOptions) (bookmarks []model.Bookmark, err error) {
+	tx := db.gorm.Find(&bookmarks)
+	return bookmarks, tx.Error
+}
+
+// GetBookmarksCount fetch count of bookmarks based on submitted options.
+func (db *GormDatabase) GetBookmarksCount(ctx context.Context, opts GetBookmarksOptions) (c int, err error) {
+	return
+}
+
+// DeleteBookmarks removes all record with matching ids from database.
+func (db *GormDatabase) DeleteBookmarks(ctx context.Context, ids ...int) error {
+	return nil
+}
+
+// GetBookmark fetches bookmark based on its ID or URL.
+// Returns the bookmark and boolean whether it's exist or not.
+func (db *GormDatabase) GetBookmark(ctx context.Context, id int, url string) (bookmark model.Bookmark, exists bool, err error) {
+	return
+}
+
+// SaveAccount saves new account to database. Returns error if any happened.
+func (db *GormDatabase) SaveAccount(ctx context.Context, account model.Account) error {
+	return nil
+}
+
+// GetAccounts fetch list of account (without its password) based on submitted options.
+func (db *GormDatabase) GetAccounts(ctx context.Context, opts GetAccountsOptions) (accounts []model.Account, err error) {
+	return
+}
+
+// GetAccount fetch account with matching username.
+// Returns the account and boolean whether it's exist or not.
+func (db *GormDatabase) GetAccount(ctx context.Context, username string) (account model.Account, exists bool, err error) {
+	tx := db.gorm.First(&account, "username = ?", username)
+	return account, account.ID != 0, tx.Error
+}
+
+// DeleteAccounts removes all record with matching usernames.
+func (db *GormDatabase) DeleteAccounts(ctx context.Context, usernames ...string) error {
+
+	return nil
+}
+
+// GetTags fetch list of tags and their frequency.
+func (db *GormDatabase) GetTags(ctx context.Context) (tags []model.Tag, err error) {
+	tx := db.gorm.Find(&tags)
+	return tags, tx.Error
+}
+
+// RenameTag change the name of a tag.
+func (db *GormDatabase) RenameTag(ctx context.Context, id int, newName string) error {
+	return nil
+}
+
+// CreateNewID creates new ID for specified table
+func (db *GormDatabase) CreateNewID(ctx context.Context, table string) (n int, err error) {
+	return
+}

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -1,35 +1,52 @@
 package model
 
+import "gorm.io/gorm"
+
 // Tag is the tag for a bookmark.
 type Tag struct {
-	ID         int    `db:"id"          json:"id"`
-	Name       string `db:"name"        json:"name"`
-	NBookmarks int    `db:"n_bookmarks" json:"nBookmarks,omitempty"`
-	Deleted    bool   `json:"-"`
+	gorm.Model
+	ID         int    `gorm:"id,primaryKey,index"          json:"id"`
+	Name       string `gorm:"name"        json:"name"`
+	NBookmarks int    `gorm:"n_bookmarks" json:"nBookmarks,omitempty"`
+	Deleted    bool   `gorm:"-" json:"-"`
+}
+
+func (Tag) TableName() string {
+	return "tag"
 }
 
 // Bookmark is the record for an URL.
 type Bookmark struct {
-	ID            int    `db:"id"            json:"id"`
-	URL           string `db:"url"           json:"url"`
-	Title         string `db:"title"         json:"title"`
-	Excerpt       string `db:"excerpt"       json:"excerpt"`
-	Author        string `db:"author"        json:"author"`
-	Public        int    `db:"public"        json:"public"`
-	Modified      string `db:"modified"      json:"modified"`
-	Content       string `db:"content"       json:"-"`
-	HTML          string `db:"html"          json:"html,omitempty"`
-	ImageURL      string `db:"image_url"     json:"imageURL"`
-	HasContent    bool   `db:"has_content"   json:"hasContent"`
-	HasArchive    bool   `json:"hasArchive"`
-	Tags          []Tag  `json:"tags"`
-	CreateArchive bool   `json:"createArchive"`
+	gorm.Model
+	ID            int    `gorm:"id,primaryKey,index"            json:"id"`
+	URL           string `gorm:"url"           json:"url"`
+	Title         string `gorm:"title"         json:"title"`
+	Excerpt       string `gorm:"excerpt"       json:"excerpt"`
+	Author        string `gorm:"author"        json:"author"`
+	Public        int    `gorm:"public"        json:"public"`
+	Modified      string `gorm:"modified"      json:"modified"`
+	Content       string `gorm:"content"       json:"-"`
+	HTML          string `gorm:"html"          json:"html,omitempty"`
+	ImageURL      string `gorm:"image_url"     json:"imageURL"`
+	HasContent    bool   `gorm:"has_content"   json:"hasContent"`
+	HasArchive    bool   `gorm:"-" json:"hasArchive"`
+	Tags          []Tag  `gorm:"many2many:bookmark_tag;" json:"tags"`
+	CreateArchive bool   `gorm:"-" json:"createArchive"`
+}
+
+func (Bookmark) TableName() string {
+	return "bookmark"
 }
 
 // Account is person that allowed to access web interface.
 type Account struct {
-	ID       int    `db:"id"       json:"id"`
-	Username string `db:"username" json:"username"`
-	Password string `db:"password" json:"password,omitempty"`
-	Owner    bool   `db:"owner"    json:"owner"`
+	gorm.Model
+	ID       int    `gorm:"id,primaryKey,index" json:"id"`
+	Username string `gorm:"username" json:"username"`
+	Password string `gorm:"password" json:"password,omitempty"`
+	Owner    bool   `gorm:"owner"    json:"owner"`
+}
+
+func (Account) TableName() string {
+	return "account"
 }


### PR DESCRIPTION
Experiment to incorporate [gorm](https://gorm.io/) into Shiori to take care of all the database logic, instead of having to maintain three different implementations, migrations and logic.
