### PR TITLE
fix: import should respect add_date or last_modified fields

### DIFF
--- a/internal/cmd/export.go
+++ b/internal/cmd/export.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/go-shiori/shiori/internal/database"
+	"github.com/go-shiori/shiori/internal/model"
 	"github.com/spf13/cobra"
 )
 
@@ -59,7 +60,7 @@ func exportHandler(cmd *cobra.Command, args []string) {
 
 	for _, book := range bookmarks {
 		// Create Unix timestamp for bookmark
-		modifiedTime, err := time.Parse("2006-01-02 15:04:05", book.Modified)
+		modifiedTime, err := time.Parse(model.DatabaseDateFormat, book.Modified)
 		if err != nil {
 			modifiedTime = time.Now()
 		}

--- a/internal/cmd/pocket.go
+++ b/internal/cmd/pocket.go
@@ -102,7 +102,7 @@ func pocketHandler(cmd *cobra.Command, args []string) {
 			ID:       bookID,
 			URL:      url,
 			Title:    title,
-			Modified: modified.Format("2006-01-02 15:04:05"),
+			Modified: modified.Format(model.DatabaseDateFormat),
 			Tags:     tags,
 		}
 

--- a/internal/database/mysql.go
+++ b/internal/database/mysql.go
@@ -108,7 +108,7 @@ func (db *MySQLDatabase) SaveBookmarks(ctx context.Context, bookmarks ...model.B
 		}
 
 		// Prepare modified time
-		modifiedTime := time.Now().UTC().Format("2006-01-02 15:04:05")
+		modifiedTime := time.Now().UTC().Format(model.DatabaseDateFormat)
 
 		// Execute statements
 

--- a/internal/database/mysql.go
+++ b/internal/database/mysql.go
@@ -127,7 +127,9 @@ func (db *MySQLDatabase) SaveBookmarks(ctx context.Context, bookmarks ...model.B
 			}
 
 			// Set modified time
-			book.Modified = modifiedTime
+			if book.Modified == "" {
+				book.Modified = modifiedTime
+			}
 
 			// Save bookmark
 			_, err := stmtInsertBook.ExecContext(ctx, book.ID,

--- a/internal/database/pg.go
+++ b/internal/database/pg.go
@@ -107,7 +107,7 @@ func (db *PGDatabase) SaveBookmarks(ctx context.Context, bookmarks ...model.Book
 		}
 
 		// Prepare modified time
-		modifiedTime := time.Now().UTC().Format("2006-01-02 15:04:05")
+		modifiedTime := time.Now().UTC().Format(model.DatabaseDateFormat)
 
 		// Execute statements
 		result = []model.Bookmark{}

--- a/internal/database/pg.go
+++ b/internal/database/pg.go
@@ -126,7 +126,9 @@ func (db *PGDatabase) SaveBookmarks(ctx context.Context, bookmarks ...model.Book
 			}
 
 			// Set modified time
-			book.Modified = modifiedTime
+			if book.Modified == "" {
+				book.Modified = modifiedTime
+			}
 
 			// Save bookmark
 			_, err := stmtInsertBook.ExecContext(ctx,

--- a/internal/database/sqlite.go
+++ b/internal/database/sqlite.go
@@ -144,7 +144,9 @@ func (db *SQLiteDatabase) SaveBookmarks(ctx context.Context, bookmarks ...model.
 			}
 
 			// Set modified time
-			book.Modified = modifiedTime
+			if book.Modified == "" {
+				book.Modified = modifiedTime
+			}
 
 			// Save bookmark
 			hasContent := book.Content != ""
@@ -234,7 +236,7 @@ func (db *SQLiteDatabase) SaveBookmarks(ctx context.Context, bookmarks ...model.
 // GetBookmarks fetch list of bookmarks based on submitted options.
 func (db *SQLiteDatabase) GetBookmarks(ctx context.Context, opts GetBookmarksOptions) ([]model.Bookmark, error) {
 	// Create initial query
-	query := `SELECT 
+	query := `SELECT
 		b.id,
 		b.url,
 		b.title,

--- a/internal/database/sqlite.go
+++ b/internal/database/sqlite.go
@@ -125,7 +125,7 @@ func (db *SQLiteDatabase) SaveBookmarks(ctx context.Context, bookmarks ...model.
 		}
 
 		// Prepare modified time
-		modifiedTime := time.Now().UTC().Format("2006-01-02 15:04:05")
+		modifiedTime := time.Now().UTC().Format(model.DatabaseDateFormat)
 
 		// Execute statements
 

--- a/internal/model/const.go
+++ b/internal/model/const.go
@@ -1,0 +1,3 @@
+package model
+
+const DatabaseDateFormat = "2006-01-02 15:04:05"


### PR DESCRIPTION
- Import command now respects the `ADD_DATE` or `LAST_MODIFIED` field, with the latter taking priority.
- Fixed a bug where saving a bookmarks would always set the modified date to the current date instead of using the set modified on the bookmark.

Fixes #121 