### PR TITLE
fix: failed to save bookmark: constraint failed: UNIQUE constraint failed: bookmark.url

### DIFF
--- a/internal/database/database_test.go
+++ b/internal/database/database_test.go
@@ -13,10 +13,11 @@ type testDatabaseFactory func(ctx context.Context) (DB, error)
 
 func testDatabase(t *testing.T, dbFactory testDatabaseFactory) {
 	tests := map[string]databaseTestCase{
-		"testCreateBookmark":        testCreateBookmark,
-		"testCreateBookmarkTwice":   testCreateBookmarkTwice,
-		"testCreateBookmarkWithTag": testCreateBookmarkWithTag,
-		"testUpdateBookmark":        testUpdateBookmark,
+		"testCreateBookmark":              testCreateBookmark,
+		"testCreateBookmarkTwice":         testCreateBookmarkTwice,
+		"testCreateBookmarkWithTag":       testCreateBookmarkWithTag,
+		"testCreateTwoDifferentBookmarks": testCreateTwoDifferentBookmarks,
+		"testUpdateBookmark":              testUpdateBookmark,
 	}
 
 	for testName, testCase := range tests {
@@ -79,6 +80,25 @@ func testCreateBookmarkTwice(t *testing.T, db DB) {
 
 	_, err = db.SaveBookmarks(ctx, true, savedBookmark)
 	assert.Error(t, err, "Save bookmarks must fail")
+}
+
+func testCreateTwoDifferentBookmarks(t *testing.T, db DB) {
+	ctx := context.TODO()
+
+	book := model.Bookmark{
+		URL:   "https://github.com/go-shiori/shiori",
+		Title: "shiori",
+	}
+
+	_, err := db.SaveBookmarks(ctx, true, book)
+	assert.NoError(t, err, "Save first bookmark must not fail")
+
+	book = model.Bookmark{
+		URL:   "https://github.com/go-shiori/go-readability",
+		Title: "go-readability",
+	}
+	_, err = db.SaveBookmarks(ctx, true, book)
+	assert.NoError(t, err, "Save second bookmark must not fail")
 }
 
 func testUpdateBookmark(t *testing.T, db DB) {

--- a/internal/database/mysql.go
+++ b/internal/database/mysql.go
@@ -84,7 +84,8 @@ func (db *MySQLDatabase) SaveBookmarks(ctx context.Context, create bool, bookmar
 			public   = ?,
 			content  = ?,
 			html     = ?,
-			modified = ?`)
+			modified = ?
+		WHERE id = ?`)
 		if err != nil {
 			return errors.WithStack(err)
 		}
@@ -149,7 +150,7 @@ func (db *MySQLDatabase) SaveBookmarks(ctx context.Context, create bool, bookmar
 			} else {
 				_, err = stmtUpdateBook.ExecContext(ctx,
 					book.URL, book.Title, book.Excerpt, book.Author,
-					book.Public, book.Content, book.HTML, book.Modified)
+					book.Public, book.Content, book.HTML, book.Modified, book.ID)
 			}
 			if err != nil {
 				return errors.WithStack(err)

--- a/internal/database/pg.go
+++ b/internal/database/pg.go
@@ -84,7 +84,8 @@ func (db *PGDatabase) SaveBookmarks(ctx context.Context, create bool, bookmarks 
 			public   = $5,
 			content  = $6,
 			html     = $7,
-			modified = $8`)
+			modified = $8
+			WHERE id = $9`)
 		if err != nil {
 			return errors.WithStack(err)
 		}
@@ -140,7 +141,7 @@ func (db *PGDatabase) SaveBookmarks(ctx context.Context, create bool, bookmarks 
 			} else {
 				_, err = stmtUpdateBook.ExecContext(ctx,
 					book.URL, book.Title, book.Excerpt, book.Author,
-					book.Public, book.Content, book.HTML, book.Modified)
+					book.Public, book.Content, book.HTML, book.Modified, book.ID)
 			}
 			if err != nil {
 				return errors.WithStack(err)

--- a/internal/database/sqlite.go
+++ b/internal/database/sqlite.go
@@ -88,7 +88,8 @@ func (db *SQLiteDatabase) SaveBookmarks(ctx context.Context, create bool, bookma
 
 		stmtUpdateBook, err := tx.PreparexContext(ctx, `UPDATE bookmark SET
 			url = ?, title = ?,	excerpt = ?, author = ?,
-			public = ?, modified = ?, has_content = ?`)
+			public = ?, modified = ?, has_content = ?
+			WHERE id = ?`)
 		if err != nil {
 			return errors.WithStack(err)
 		}
@@ -158,8 +159,7 @@ func (db *SQLiteDatabase) SaveBookmarks(ctx context.Context, create bool, bookma
 					book.URL, book.Title, book.Excerpt, book.Author, book.Public, book.Modified, hasContent).Scan(&book.ID)
 			} else {
 				_, err = stmtUpdateBook.ExecContext(ctx,
-					book.URL, book.Title, book.Excerpt, book.Author, book.Public, book.Modified, hasContent)
-
+					book.URL, book.Title, book.Excerpt, book.Author, book.Public, book.Modified, hasContent, book.ID)
 			}
 			if err != nil {
 				return errors.WithStack(err)


### PR DESCRIPTION
After a first bookmark save, all subsequent ones fail because the update query does not include an identifier and the update is done on all rows.

Add a test to create two different bookmarks.

Introduced by 05fee53bd0b7e81b5e74c4ae9efcbe213b563744