### PR TITLE
fix(api-ext): use same save logic as the api

### DIFF
--- a/internal/database/database_test.go
+++ b/internal/database/database_test.go
@@ -16,10 +16,12 @@ func testDatabase(t *testing.T, dbFactory testDatabaseFactory) {
 		"testCreateBookmark":              testCreateBookmark,
 		"testCreateBookmarkTwice":         testCreateBookmarkTwice,
 		"testCreateBookmarkWithTag":       testCreateBookmarkWithTag,
+		"testCreateTwoDifferentBookmarks": testCreateTwoDifferentBookmarks,
 		"testUpdateBookmark":              testUpdateBookmark,
+		"testGetBookmark":                 testGetBookmark,
+		"testGetBookmarkNotExistant":      testGetBookmarkNotExistant,
 		"testGetBookmarks":                testGetBookmarks,
 		"testGetBookmarksCount":           testGetBookmarksCount,
-    "testCreateTwoDifferentBookmarks": testCreateTwoDifferentBookmarks,
 	}
 
 	for testName, testCase := range tests {
@@ -122,6 +124,33 @@ func testUpdateBookmark(t *testing.T, db DB) {
 
 	assert.Equal(t, "modified", result[0].Title)
 	assert.Equal(t, savedBookmark.ID, result[0].ID)
+}
+
+func testGetBookmark(t *testing.T, db DB) {
+	ctx := context.TODO()
+
+	book := model.Bookmark{
+		URL:   "https://github.com/go-shiori/shiori",
+		Title: "shiori",
+	}
+
+	result, err := db.SaveBookmarks(ctx, true, book)
+	assert.NoError(t, err, "Save bookmarks must not fail")
+
+	savedBookmark, exists, err := db.GetBookmark(ctx, result[0].ID, "")
+	assert.True(t, exists, "Bookmark should exist")
+	assert.NoError(t, err, "Get bookmark should not fail")
+	assert.Equal(t, result[0].ID, savedBookmark.ID, "Retrieved bookmark should be the same")
+	assert.Equal(t, book.URL, savedBookmark.URL, "Retrieved bookmark should be the same")
+}
+
+func testGetBookmarkNotExistant(t *testing.T, db DB) {
+	ctx := context.TODO()
+
+	savedBookmark, exists, err := db.GetBookmark(ctx, 1, "")
+	assert.NoError(t, err, "Get bookmark should not fail")
+	assert.False(t, exists, "Bookmark should not exist")
+	assert.Equal(t, model.Bookmark{}, savedBookmark)
 }
 
 func testGetBookmarks(t *testing.T, db DB) {

--- a/internal/database/mysql.go
+++ b/internal/database/mysql.go
@@ -512,7 +512,7 @@ func (db *MySQLDatabase) GetBookmark(ctx context.Context, id int, url string) (m
 	}
 
 	book := model.Bookmark{}
-	if err := db.GetContext(ctx, &book, query, args...); err != nil {
+	if err := db.GetContext(ctx, &book, query, args...); err != nil && err != sql.ErrNoRows {
 		return book, false, errors.WithStack(err)
 	}
 

--- a/internal/database/pg.go
+++ b/internal/database/pg.go
@@ -521,7 +521,7 @@ func (db *PGDatabase) GetBookmark(ctx context.Context, id int, url string) (mode
 	}
 
 	book := model.Bookmark{}
-	if err := db.GetContext(ctx, &book, query, args...); err != nil {
+	if err := db.GetContext(ctx, &book, query, args...); err != nil && err != sql.ErrNoRows {
 		return book, false, errors.WithStack(err)
 	}
 

--- a/internal/database/sqlite.go
+++ b/internal/database/sqlite.go
@@ -635,7 +635,7 @@ func (db *SQLiteDatabase) GetBookmark(ctx context.Context, id int, url string) (
 	}
 
 	book := model.Bookmark{}
-	if err := db.GetContext(ctx, &book, query, args...); err != nil {
+	if err := db.GetContext(ctx, &book, query, args...); err != nil && err != sql.ErrNoRows {
 		return book, false, errors.WithStack(err)
 	}
 

--- a/internal/webserver/handler.go
+++ b/internal/webserver/handler.go
@@ -91,21 +91,17 @@ func (h *handler) prepareTemplates() error {
 }
 
 func (h *handler) getSessionID(r *http.Request) string {
-	// Get session-id from header and cookie
-	headerSessionID := r.Header.Get("X-Session-Id")
-	cookieSessionID := func() string {
+	// Try to get session ID from the header
+	sessionID := r.Header.Get("X-Session-Id")
+
+	// If not, try it from the cookie
+	if sessionID == "" {
 		cookie, err := r.Cookie("session-id")
 		if err != nil {
 			return ""
 		}
 
-		return cookie.Value
-	}()
-
-	// Session ID in cookie is more priority than in header
-	sessionID := headerSessionID
-	if cookieSessionID != "" {
-		sessionID = cookieSessionID
+		sessionID = cookie.Value
 	}
 
 	return sessionID


### PR DESCRIPTION
- Modified the extension API to use the same save flow as the regular API, by generating the bookmark first and trying to archive it later. This will result in a stored bookmark even if the archiving fails.
- Switched the session priority, now the header has more priority than the cookie, witch should be the default, since the webserver sends the cookie and the extension requires the session anyway.
- Fixed the `DB.GetBookmark` method by handling the `sql.ErrNoRows` silently (since it already exposes a `bool`).

Fixes #517