### PR TITLE
fix: remove createnewid usages

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -17,6 +17,7 @@ services:
       - "mariadb"
     environment:
       SHIORI_DBMS: mysql
+      SHIORI_DIR: /srv/shiori
       SHIORI_PG_USER: shiori
       SHIORI_PG_PASS: shiori
       SHIORI_PG_NAME: shiori

--- a/internal/cmd/add.go
+++ b/internal/cmd/add.go
@@ -56,20 +56,27 @@ func addHandler(cmd *cobra.Command, args []string) {
 		book.Tags[i].Name = strings.TrimSpace(tag)
 	}
 
-	// Create bookmark ID
-	var err error
-	book.ID, err = db.CreateNewID(cmd.Context(), "bookmark")
-	if err != nil {
-		cError.Printf("Failed to create ID: %v\n", err)
-		os.Exit(1)
-	}
-
 	// Clean up bookmark URL
+	var err error
 	book.URL, err = core.RemoveUTMParams(book.URL)
 	if err != nil {
 		cError.Printf("Failed to clean URL: %v\n", err)
 		os.Exit(1)
 	}
+
+	// Make sure bookmark's title not empty
+	if book.Title == "" {
+		book.Title = book.URL
+	}
+
+	// Save bookmark to database
+	books, err := db.SaveBookmarks(cmd.Context(), true, book)
+	if err != nil {
+		cError.Printf("Failed to save bookmark: %v\n", err)
+		os.Exit(1)
+	}
+
+	book = books[0]
 
 	// If it's not offline mode, fetch data from internet.
 	if !offline {
@@ -103,18 +110,13 @@ func addHandler(cmd *cobra.Command, args []string) {
 				os.Exit(1)
 			}
 		}
-	}
 
-	// Make sure bookmark's title not empty
-	if book.Title == "" {
-		book.Title = book.URL
-	}
-
-	// Save bookmark to database
-	_, err = db.SaveBookmarks(cmd.Context(), true, book)
-	if err != nil {
-		cError.Printf("Failed to save bookmark: %v\n", err)
-		os.Exit(1)
+		// Save bookmark to database
+		_, err = db.SaveBookmarks(cmd.Context(), false, book)
+		if err != nil {
+			cError.Printf("Failed to save bookmark with content: %v\n", err)
+			os.Exit(1)
+		}
 	}
 
 	// Print added bookmark

--- a/internal/cmd/import.go
+++ b/internal/cmd/import.go
@@ -41,13 +41,6 @@ func importHandler(cmd *cobra.Command, args []string) {
 		generateTag = submit == "y"
 	}
 
-	// Prepare bookmark's ID
-	bookID, err := db.CreateNewID(cmd.Context(), "bookmark")
-	if err != nil {
-		cError.Printf("Failed to create ID: %v\n", err)
-		os.Exit(1)
-	}
-
 	// Open bookmark's file
 	srcFile, err := os.Open(args[0])
 	if err != nil {
@@ -141,14 +134,12 @@ func importHandler(cmd *cobra.Command, args []string) {
 
 		// Add item to list
 		bookmark := model.Bookmark{
-			ID:       bookID,
 			URL:      url,
 			Title:    title,
 			Tags:     tags,
 			Modified: modifiedDate.Format(model.DatabaseDateFormat),
 		}
 
-		bookID++
 		mapURL[url] = struct{}{}
 		bookmarks = append(bookmarks, bookmark)
 	})

--- a/internal/cmd/pocket.go
+++ b/internal/cmd/pocket.go
@@ -25,13 +25,6 @@ func pocketCmd() *cobra.Command {
 }
 
 func pocketHandler(cmd *cobra.Command, args []string) {
-	// Prepare bookmark's ID
-	bookID, err := db.CreateNewID(cmd.Context(), "bookmark")
-	if err != nil {
-		cError.Printf("Failed to create ID: %v\n", err)
-		return
-	}
-
 	// Open pocket's file
 	srcFile, err := os.Open(args[0])
 	if err != nil {
@@ -99,14 +92,12 @@ func pocketHandler(cmd *cobra.Command, args []string) {
 
 		// Add item to list
 		bookmark := model.Bookmark{
-			ID:       bookID,
 			URL:      url,
 			Title:    title,
 			Modified: modified.Format(model.DatabaseDateFormat),
 			Tags:     tags,
 		}
 
-		bookID++
 		mapURL[url] = struct{}{}
 		bookmarks = append(bookmarks, bookmark)
 	})

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -80,9 +80,6 @@ type DB interface {
 
 	// RenameTag change the name of a tag.
 	RenameTag(ctx context.Context, id int, newName string) error
-
-	// CreateNewID creates new id for specified table.
-	CreateNewID(ctx context.Context, table string) (int, error)
 }
 
 type dbbase struct {

--- a/internal/database/mysql.go
+++ b/internal/database/mysql.go
@@ -3,7 +3,6 @@ package database
 import (
 	"context"
 	"database/sql"
-	"fmt"
 	"strings"
 	"time"
 
@@ -623,17 +622,4 @@ func (db *MySQLDatabase) RenameTag(ctx context.Context, id int, newName string) 
 	})
 
 	return errors.WithStack(err)
-}
-
-// CreateNewID creates new ID for specified table
-func (db *MySQLDatabase) CreateNewID(ctx context.Context, table string) (int, error) {
-	var tableID int
-	query := fmt.Sprintf(`SELECT IFNULL(MAX(id) + 1, 1) FROM %s`, table)
-
-	err := db.GetContext(ctx, &tableID, query)
-	if err != nil && err != sql.ErrNoRows {
-		return -1, errors.WithStack(err)
-	}
-
-	return tableID, nil
 }

--- a/internal/database/pg.go
+++ b/internal/database/pg.go
@@ -634,16 +634,3 @@ func (db *PGDatabase) RenameTag(ctx context.Context, id int, newName string) err
 
 	return nil
 }
-
-// CreateNewID creates new ID for specified table
-func (db *PGDatabase) CreateNewID(ctx context.Context, table string) (int, error) {
-	var tableID int
-	query := fmt.Sprintf(`SELECT last_value from %s_id_seq;`, table)
-
-	err := db.GetContext(ctx, &tableID, query)
-	if err != nil && err != sql.ErrNoRows {
-		return -1, err
-	}
-
-	return tableID, nil
-}

--- a/internal/database/sqlite.go
+++ b/internal/database/sqlite.go
@@ -3,7 +3,6 @@ package database
 import (
 	"context"
 	"database/sql"
-	"fmt"
 	"log"
 	"strings"
 	"time"
@@ -176,13 +175,6 @@ func (db *SQLiteDatabase) SaveBookmarks(ctx context.Context, create bool, bookma
 			if err != nil {
 				return errors.WithStack(err)
 			}
-
-			bookID, err := res.LastInsertId()
-			if err != nil {
-				return errors.WithStack(err)
-			}
-
-			book.ID = int(bookID)
 
 			if rows == 0 {
 				_, err = stmtInsertBookContent.ExecContext(ctx, book.ID, book.Title, book.Content, book.HTML)
@@ -757,17 +749,4 @@ func (db *SQLiteDatabase) RenameTag(ctx context.Context, id int, newName string)
 	}
 
 	return nil
-}
-
-// CreateNewID creates new ID for specified table
-func (db *SQLiteDatabase) CreateNewID(ctx context.Context, table string) (int, error) {
-	var tableID int
-	query := fmt.Sprintf(`SELECT IFNULL(MAX(id) + 1, 1) FROM %s`, table)
-
-	err := db.GetContext(ctx, &tableID, query)
-	if err != nil && err != sql.ErrNoRows {
-		return -1, errors.WithStack(err)
-	}
-
-	return tableID, nil
 }


### PR DESCRIPTION
This pull request removes the definition, implementation and usage of `CreateNewID` now that the `SaveBookmarks` implementation differentiates between a creation and a deletion, and make the creation homogenous between the CLI and the API, though not using common code for now.

Fixes #271