### PR TITLE
Remove typo in compose Dockerfile post-run command

### DIFF
--- a/Dockerfile.compose
+++ b/Dockerfile.compose
@@ -3,4 +3,4 @@ FROM docker.io/golang:1.19-alpine3.16
 WORKDIR /src/shiori
 
 ENTRYPOINT ["go", "run", "main.go"]
-CMD ["server"]
+CMD ["serve"]


### PR DESCRIPTION
This should be `serve` not `server` 

server was causing it to freak out about the typo.