### PR TITLE
ci: fix goreleaser snapshots

### DIFF
--- a/.github/workflows/_gorelease.yml
+++ b/.github/workflows/_gorelease.yml
@@ -13,6 +13,8 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
+      - if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
+        run: echo "flags=--snapshot" >> $GITHUB_ENV
       - name: Setup Go
         uses: actions/setup-go@v3
         with:
@@ -22,7 +24,7 @@ jobs:
         with:
           distribution: goreleaser
           version: latest
-          args: release --rm-dist
+          args: release --rm-dist ${{ env.flags }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions/upload-artifact@v3


### PR DESCRIPTION
The update to goreleaser v4 #544 broke the auto-snapshot integration (https://github.com/goreleaser/goreleaser-action/pull/382). This changes adds the `--snapshot` flag to goreleaser when required.