### PR TITLE
feat: improve bookmark image detection

### DIFF
--- a/internal/core/processing.go
+++ b/internal/core/processing.go
@@ -159,7 +159,11 @@ func downloadBookImage(url, dstPath string) error {
 
 	// Make sure it's JPG or PNG image
 	cp := resp.Header.Get("Content-Type")
-	if !strings.Contains(cp, "image/jpeg") && !strings.Contains(cp, "image/png") {
+	if !strings.Contains(cp, "image/jpeg") &&
+		!strings.Contains(cp, "image/pjpeg") &&
+		!strings.Contains(cp, "image/jpg") &&
+		!strings.Contains(cp, "image/png") {
+
 		return fmt.Errorf("%s is not a supported image", url)
 	}
 


### PR DESCRIPTION
Unfortunately, not all web servers are configured correctly. I found a [detailed comment on Stack Overflow](https://stackoverflow.com/a/54488403) from which it becomes clear that the MIME type `image/jpg` does not exist. But I am faced with the fact that on some servers, however, this type is specified. And as a result, the cover does not load.

Here is an example of a link: https://vc.ru/581066

```bash
$ curl -I -X GET "https://vc.ru/cover/fb/c/581066/1673501221/cover.jpg"

HTTP/2 200
content-type: image/jpg
```

Before and after this change:

![изображение](https://user-images.githubusercontent.com/6339978/212035927-73be752b-af67-47aa-82bc-954f2b4d3283.png)
