### PR TITLE
fix(frontend): avoid night mode flickering on reload

### DIFF
--- a/internal/view/content.html
+++ b/internal/view/content.html
@@ -19,11 +19,18 @@
 	<link href="css/custom-dialog.css" rel="stylesheet">
 	<link href="css/bookmark-item.css" rel="stylesheet">
 
+	<script>
+		(() => {
+			var opts = JSON.parse(localStorage.getItem("shiori-setting")) || {};
+			var nightMode = (typeof opts.nightMode === "boolean") ? opts.nightMode : false;
+			document.documentElement.className = nightMode ? 'night' : ''
+		})();
+	</script>
 	<script src="js/dayjs.min.js"></script>
 	<script src="js/vue.min.js"></script>
 </head>
 
-<body class="night">
+<body>
 	<div id="content-scene" :class="{night: appOptions.nightMode}">
 		<div id="header">
 			<p id="metadata" v-cloak>Added {{localtime()}}</p>
@@ -71,8 +78,6 @@
 						nightMode: nightMode,
 						useArchive: useArchive,
 					};
-
-					document.body.className = nightMode ? "night" : "";
 				}
 			},
 			mounted() {

--- a/internal/view/index.html
+++ b/internal/view/index.html
@@ -20,11 +20,19 @@
 	<link href="css/custom-dialog.css" rel="stylesheet">
 	<link href="css/bookmark-item.css" rel="stylesheet">
 
+	<script>
+		(() => {
+			var opts = JSON.parse(localStorage.getItem("shiori-setting")) || {};
+			var nightMode = (typeof opts.nightMode === "boolean") ? opts.nightMode : false;
+			document.documentElement.className = nightMode ? 'night' : ''
+		})();
+	</script>
+
 	<script src="js/vue.min.js"></script>
 	<script src="js/url.min.js"></script>
 </head>
 
-<body class="night">
+<body>
 	<div id="main-scene" :class="{night: appOptions.nightMode}">
 		<div id="main-sidebar">
 			<a v-for="item in sidebarItems" :title="item.title" :class="{active: activePage === item.page}" @click="switchPage(item.page)">
@@ -106,7 +114,7 @@
 				saveSetting(opts) {
 					localStorage.setItem("shiori-setting", JSON.stringify(opts));
 					this.appOptions = opts;
-					document.body.className = opts.nightMode ? "night" : "";
+					document.documentElement.className = opts.nightMode ? 'night' : ''
 				},
 				loadSetting() {
 					var opts = JSON.parse(localStorage.getItem("shiori-setting")) || {},
@@ -129,8 +137,6 @@
 						useArchive: useArchive,
 						makePublic: makePublic,
 					};
-
-					document.body.className = nightMode ? "night" : "";
 				},
 				loadAccount() {
 					var account = JSON.parse(localStorage.getItem("shiori-account")) || {},


### PR DESCRIPTION
Hi!

Shiori pages are flickering on refresh(or initialize), you can watch the video below.

https://user-images.githubusercontent.com/5170232/215329259-f1d02b9a-3899-480e-bb44-3038a23f3a13.mp4

This patch can fix it by moving nightMode related code to `<head>`