### PR TITLE
Add log args for root command

### DIFF
--- a/internal/cmd/utils.go
+++ b/internal/cmd/utils.go
@@ -6,6 +6,7 @@ import (
 	nurl "net/url"
 	"os"
 	"os/exec"
+	"path"
 	"runtime"
 	"strconv"
 	"strings"
@@ -163,4 +164,8 @@ func validateTitle(title, fallback string) string {
 	}
 
 	return validUtf
+}
+
+func SFCallerPrettyfier(frame *runtime.Frame) (string, string) {
+	return "", fmt.Sprintf("%s:%d", path.Base(frame.File), frame.Line)
 }

--- a/main.go
+++ b/main.go
@@ -5,11 +5,10 @@ package main
 import (
 	"github.com/go-shiori/shiori/internal/cmd"
 	"github.com/sirupsen/logrus"
-
 	// Database driver
 	_ "github.com/go-sql-driver/mysql"
 	_ "github.com/lib/pq"
-	_  "modernc.org/sqlite"
+	_ "modernc.org/sqlite"
 
 	// Add this to prevent it removed by go mod tidy
 	_ "github.com/shurcooL/vfsgen"


### PR DESCRIPTION
For improved debugging convenience, add some log flags in root command

- log-level: specify log level, default info
- log-caller: whether log `file:lineno` or not, default false
- log FullTimestamp