### PR TITLE
Use UTC for cookie expiry date in backend

### DIFF
--- a/internal/webserver/handler-api.go
+++ b/internal/webserver/handler-api.go
@@ -86,7 +86,7 @@ func (h *handler) apiLogin(w http.ResponseWriter, r *http.Request, ps httprouter
 			Session string        `json:"session"`
 			Account model.Account `json:"account"`
 			Expires string        `json:"expires"`
-		}{strSessionID, account, time.Now().Add(expTime).Format(time.RFC1123)}
+		}{strSessionID, account, time.Now().UTC().Add(expTime).Format(time.RFC1123)}
 
 		w.Header().Set("Content-Type", "application/json")
 		err = json.NewEncoder(w).Encode(&loginResult)


### PR DESCRIPTION
**Issue:**
Logging in to the web UI for the first time resulted in 301 redirect on v1.5.4. Only seems to be an issue on chromium based browsers (Brave, Chrome, Edge). Not an issue on Firefox as far as I can tell. 

**Solution:**
[JavaScript documents indicate cookie expires attribute should be UTC format ](https://developer.mozilla.org/en-US/docs/Web/API/Document/cookie). After cba5046 expiry date is returned in local time format instead of UTC. Updating backed to explicitly use UTC resolves the issue.