### PR TITLE
fix download data image fix #645

### DIFF
--- a/internal/core/ebook.go
+++ b/internal/core/ebook.go
@@ -245,7 +245,9 @@ func GetImages(html string) (map[string]string, error) {
 	// Loop through all the matches and add them to the dictionary
 	for _, match := range imageTagMatches {
 		imageURL := match[1]
-		images[imageURL] = match[0]
+		if !strings.HasPrefix(imageURL, "data:image/") {
+			images[imageURL] = match[0]
+		}
 	}
 
 	return images, nil


### PR DESCRIPTION
This PR fix problem that download mechanism tried to get data/image.
It should not happen (they are not a real URL that point to the specific server, they are actual data)
by excluding them, we can handle data/image too.
Caliber or modern browser can handle this kind of links itself.
Will fix #645

for [Future reference](https://en.wikipedia.org/wiki/Data_URI_scheme)