### PR TITLE
[docs update] Add guidance for deploying with Fly.io

### DIFF
--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -48,6 +48,34 @@ docker pull ghcr.io/go-shiori/shiori
 
 > This docker image is based on the [Dockerfile.ci](../.github/workflows/docker/Dockerfile.ci)
 
+### Deploying with Fly.io
+
+You can also deploy direclty with [Fly.io](https://fly.io) using the docker image[^1]. 
+[^1]: Thanks to [Oscar Carlsson's post](https://www.monotux.tech/posts/2022/09/more-flies-please/)
+
+1. lauch a new Fly.io app, and create permanent storage 
+```shell
+cd directory-where-you-store-your-shiori-flyio-toml
+flyctl launch --no-deploy
+flyctl volumes create shiori_data --size 1
+```
+2. Add the following sections to your fly.toml:
+```shell
+[build]
+  image = "ghcr.io/go-shiori/shiori:latest"
+
+[mounts]
+  source="shiori_data" # change it if you use another volume name in step 1
+  destination="/shiori"
+```
+
+3. Deploy
+```shell
+flyctl deploy
+```
+
+4. Now the shiori app should run like expected - the default username is `shiori` and the default password is `gopher`. This account will be removed when you’ve added a new account through the web-UI. You can run `flyctl open` to open your Shiori.
+
 ## Building docker image
 
 If you want to build the Docker image on your own, Shiori already has its [Dockerfile](https://github.com/go-shiori/shiori/blob/master/Dockerfile), so you can build the Docker image by running :


### PR DESCRIPTION
## what this PR is about
This PR updated `Installation.md`, to add guidance for deploying Shiori with Fly.io.

## why it's needed
As many people look for self-hosting bookmark service, it would be great if the docs can provide them with a straight-forward and easy way to quickly set up an instance without diving into too much tech details. 

## notes for maintainer
This change is only a doc update, and doesn't affect any functionality of the project.
This PR has the same content as #705, but pushing to `fmartingr/issue663` per requested by @fmartingr .