### PR TITLE
fix(db): handle usage of special characters in searches

### DIFF
--- a/internal/database/database_test.go
+++ b/internal/database/database_test.go
@@ -273,14 +273,21 @@ func testGetBookmarksWithSQLCharacters(t *testing.T, db DB) {
 	_, err := db.SaveBookmarks(ctx, true, book)
 	assert.NoError(t, err, "Save bookmarks must not fail")
 
-	characters := []string{";", "%", "_", "\\", "\""}
+	characters := []string{";", "%", "_", "\\", "\"", ":"}
 
 	for _, char := range characters {
-		t.Run(char, func(t *testing.T) {
+		t.Run("GetBookmarks/"+char, func(t *testing.T) {
 			_, err := db.GetBookmarks(ctx, GetBookmarksOptions{
 				Keyword: char,
 			})
 			assert.NoError(t, err, "Get bookmarks should not fail")
+		})
+
+		t.Run("GetBookmarksCount/"+char, func(t *testing.T) {
+			_, err := db.GetBookmarksCount(ctx, GetBookmarksOptions{
+				Keyword: char,
+			})
+			assert.NoError(t, err, "Get bookmarks count should not fail")
 		})
 	}
 }

--- a/internal/database/pg.go
+++ b/internal/database/pg.go
@@ -237,13 +237,12 @@ func (db *PGDatabase) GetBookmarks(ctx context.Context, opts GetBookmarksOptions
 	// Add where clause for search keyword
 	if opts.Keyword != "" {
 		query += ` AND (
-			url LIKE :lkw OR
-			title LIKE :kw OR
-			excerpt LIKE :kw OR
-			content LIKE :kw
+			url LIKE '%' || :kw || '%' OR
+			title LIKE '%' || :kw || '%' OR
+			excerpt LIKE '%' || :kw || '%' OR
+			content LIKE '%' || :kw || '%'
 		)`
 
-		arg["lkw"] = "%" + opts.Keyword + "%"
 		arg["kw"] = opts.Keyword
 	}
 

--- a/internal/database/pg.go
+++ b/internal/database/pg.go
@@ -371,10 +371,10 @@ func (db *PGDatabase) GetBookmarksCount(ctx context.Context, opts GetBookmarksOp
 	// Add where clause for search keyword
 	if opts.Keyword != "" {
 		query += ` AND (
-			url LIKE :lurl OR
-			title LIKE :kw OR
-			excerpt LIKE :kw OR
-			content LIKE :kw
+			url LIKE '%' || :kw || '%' OR
+			title LIKE '%' || :kw || '%' OR
+			excerpt LIKE '%' || :kw || '%' OR
+			content LIKE '%' || :kw || '%'
 		)`
 
 		arg["lurl"] = "%" + opts.Keyword + "%"

--- a/internal/database/sqlite.go
+++ b/internal/database/sqlite.go
@@ -270,19 +270,22 @@ func (db *SQLiteDatabase) GetBookmarks(ctx context.Context, opts GetBookmarksOpt
 
 	// Add where clause for search keyword
 	if opts.Keyword != "" {
-		query += ` AND (b.url LIKE ? OR b.excerpt LIKE ? OR b.id IN (
+		query += ` AND (b.url LIKE '%' || ? || '%' OR b.excerpt LIKE '%' || ? || '%' OR b.id IN (
 			SELECT docid id
 			FROM bookmark_content
 			WHERE title MATCH ? OR content MATCH ?))`
 
-		args = append(args,
-			"%"+opts.Keyword+"%",
-			"%"+opts.Keyword+"%")
-
-		// Replace dash with spaces since FTS5 uses `-name` as column identifier
-		opts.Keyword = strings.Replace(opts.Keyword, "-", " ", -1)
 		args = append(args, opts.Keyword, opts.Keyword)
 
+		// Replace dash with spaces since FTS5 uses `-name` as column identifier and double quote
+		// since FTS5 uses double quote as string identifier
+		// Reference: https://sqlite.org/fts5.html#fts5_strings
+		ftsKeyword := strings.Replace(opts.Keyword, "-", " ", -1)
+
+		// Properly set double quotes for string literals in sqlite's fts
+		ftsKeyword = strings.Replace(ftsKeyword, "\"", "\"\"", -1)
+
+		args = append(args, "\""+ftsKeyword+"\"", "\""+ftsKeyword+"\"")
 	}
 
 	// Add where clause for tags.


### PR DESCRIPTION
The current queries are built by concatenating strings in the code, rather than in the database, meaning we lose sanitization on the database side.

This PR adds a new test that checks queries with some special characters to avoid failures, while doing:
- String concatenation for `LIKE` queries in the query directly
- Properly quoting FTS5 search queries in SQLite
- Properly parsing double quotes in SQLite queries for FTS5.

Fixes #717 