### PR TITLE
Switch to prefix search for bookmarks

### DIFF
--- a/internal/database/mysql.go
+++ b/internal/database/mysql.go
@@ -253,7 +253,7 @@ func (db *MySQLDatabase) GetBookmarks(ctx context.Context, opts GetBookmarksOpti
 			MATCH(title, excerpt, content) AGAINST (? IN BOOLEAN MODE)
 		)`
 
-		args = append(args, "%"+opts.Keyword+"%", opts.Keyword)
+		args = append(args, "%"+opts.Keyword+"%", opts.Keyword+"*")
 	}
 
 	// Add where clause for tags.
@@ -383,7 +383,7 @@ func (db *MySQLDatabase) GetBookmarksCount(ctx context.Context, opts GetBookmark
 
 		args = append(args,
 			"%"+opts.Keyword+"%",
-			opts.Keyword)
+			opts.Keyword+"*")
 	}
 
 	// Add where clause for tags.

--- a/internal/database/sqlite.go
+++ b/internal/database/sqlite.go
@@ -285,7 +285,7 @@ func (db *SQLiteDatabase) GetBookmarks(ctx context.Context, opts GetBookmarksOpt
 		// Properly set double quotes for string literals in sqlite's fts
 		ftsKeyword = strings.ReplaceAll(ftsKeyword, "\"", "\"\"")
 
-		args = append(args, "\""+ftsKeyword+"\"", "\""+ftsKeyword+"\"")
+		args = append(args, "\""+ftsKeyword+"\" *", "\""+ftsKeyword+"\" *")
 	}
 
 	// Add where clause for tags.
@@ -479,7 +479,7 @@ func (db *SQLiteDatabase) GetBookmarksCount(ctx context.Context, opts GetBookmar
 		// Properly set double quotes for string literals in sqlite's fts
 		ftsKeyword = strings.ReplaceAll(ftsKeyword, "\"", "\"\"")
 
-		args = append(args, "\""+ftsKeyword+"\"", "\""+ftsKeyword+"\"")
+		args = append(args, "\""+ftsKeyword+"\" *", "\""+ftsKeyword+"\" *")
 	}
 
 	// Add where clause for tags.


### PR DESCRIPTION
Fixes #722.

It is not a 100% solution as I just added prefix matching, for pre- and postfix matching `LIKE` keyword would be needed, but that's a volume slower than `MATCH`.