### PR TITLE
#WIP: Webroot support on new server

### DIFF
--- a/internal/http/middleware/webroot.go
+++ b/internal/http/middleware/webroot.go
@@ -1,0 +1,23 @@
+package middleware
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+)
+
+// StripWebrootPrefixiddleware is a middleware that strips prefix from request path.
+func StripWebrootPrefixMiddleware(prefix string) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		// If prefix does not start with slash, add it
+		if !strings.HasPrefix(prefix, "/") {
+			prefix = "/" + prefix
+		}
+		fmt.Println(c.Request.URL.Path)
+		fmt.Println(prefix)
+		c.Request.URL.Path = strings.TrimPrefix(c.Request.URL.Path, prefix)
+		fmt.Println(c.Request.URL.Path)
+		c.Next()
+	}
+}

--- a/internal/http/middleware/webroot_test.go
+++ b/internal/http/middleware/webroot_test.go
@@ -1,0 +1,44 @@
+package middleware
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+)
+
+func TestStripWebrootPrefixMiddleware(t *testing.T) {
+	prefix := "/prefix"
+	// Create a new router with the middleware
+	r := gin.New()
+	r.Use(StripWebrootPrefixMiddleware(prefix))
+	r.Use(func(ctx *gin.Context) {
+		fmt.Println("asd", ctx.Request.URL.Path)
+	})
+
+	// Define a test route
+	r.GET("/test", func(c *gin.Context) {
+		c.String(http.StatusOK, "Test")
+	})
+
+	// Create a test request
+	req, err := http.NewRequest("GET", prefix+"/test", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Perform the request
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	// Check the response
+	if w.Code != http.StatusOK {
+		t.Errorf("Expected status code %d but got %d", http.StatusOK, w.Code)
+	}
+
+	if w.Body.String() != "Test" {
+		t.Errorf("Expected body %q but got %q", "Test", w.Body.String())
+	}
+}

--- a/internal/http/server.go
+++ b/internal/http/server.go
@@ -34,6 +34,10 @@ func (s *HttpServer) Setup(cfg *config.Config, deps *config.Dependencies) *HttpS
 
 	s.engine.Use(requestid.New())
 
+	if cfg.Http.RootPath != "" {
+		s.engine.Use(middleware.StripWebrootPrefixMiddleware(cfg.Http.RootPath))
+	}
+
 	if cfg.Http.AccessLog {
 		s.engine.Use(ginlogrus.Logger(deps.Log))
 	}


### PR DESCRIPTION
**Note**: I'm not sure if this will reach production, since using a reverse proxy is an user's control and most reverse proxies should have options to send the unprefixed path to their upstreams, rather than have all services underneath handle a prefix.