### PR TITLE
add create ebook by default in settings

### DIFF
--- a/docs/swagger/docs.go
+++ b/docs/swagger/docs.go
@@ -252,6 +252,9 @@ const docTemplate = `{
         "model.UserConfig": {
             "type": "object",
             "properties": {
+                "CreateEbook": {
+                    "type": "boolean"
+                },
                 "HideExcerpt": {
                     "type": "boolean"
                 },

--- a/docs/swagger/swagger.json
+++ b/docs/swagger/swagger.json
@@ -241,6 +241,9 @@
         "model.UserConfig": {
             "type": "object",
             "properties": {
+                "CreateEbook": {
+                    "type": "boolean"
+                },
                 "HideExcerpt": {
                     "type": "boolean"
                 },

--- a/docs/swagger/swagger.yaml
+++ b/docs/swagger/swagger.yaml
@@ -51,6 +51,8 @@ definitions:
     type: object
   model.UserConfig:
     properties:
+      CreateEbook:
+        type: boolean
       HideExcerpt:
         type: boolean
       HideThumbnail:

--- a/internal/core/processing.go
+++ b/internal/core/processing.go
@@ -142,6 +142,7 @@ func ProcessBookmark(req ProcessRequest) (book model.Bookmark, isFatalErr bool, 
 	// If needed, create ebook as well
 	if book.CreateEbook {
 		ebookPath := fp.Join(req.DataDir, "ebook", strID+".epub")
+		req.Bookmark = book
 
 		if strings.Contains(contentType, "application/pdf") {
 			return book, false, errors.Wrap(err, "can't create ebook from pdf")

--- a/internal/http/routes/api/v1/auth_test.go
+++ b/internal/http/routes/api/v1/auth_test.go
@@ -253,6 +253,7 @@ func TestSettingsHandler(t *testing.T) {
 				NightMode:     true,
 				KeepMetadata:  true,
 				UseArchive:    true,
+				CreateEbook:   true,
 				MakePublic:    true,
 			},
 		}
@@ -276,6 +277,7 @@ func TestSettingsHandler(t *testing.T) {
 			"NightMode": false,
 			"KeepMetadata": false,
 			"UseArchive": false,
+			"CreateEbook": false,
 			"MakePublic": false
 			  }
 			}`)

--- a/internal/model/account.go
+++ b/internal/model/account.go
@@ -23,6 +23,7 @@ type UserConfig struct {
 	NightMode     bool `json:"NightMode"`
 	KeepMetadata  bool `json:"KeepMetadata"`
 	UseArchive    bool `json:"UseArchive"`
+	CreateEbook   bool `json:"CreateEbook"`
 	MakePublic    bool `json:"MakePublic"`
 }
 

--- a/internal/view/assets/js/page/home.js
+++ b/internal/view/assets/js/page/home.js
@@ -383,6 +383,11 @@ export default {
 					type: "check",
 					value: this.appOptions.UseArchive,
 				}, {
+					name: "createEbook",
+					label: "Create Ebook",
+					type: "check",
+					value: this.appOptions.CreateEbook,
+				}, {
 					name: "makePublic",
 					label: "Make archive publicly available",
 					type: "check",

--- a/internal/view/assets/js/page/home.js
+++ b/internal/view/assets/js/page/home.js
@@ -422,6 +422,7 @@ export default {
 						public: data.makePublic ? 1 : 0,
 						tags: tags,
 						createArchive: data.createArchive,
+						createEbook: data.createEbook,
 					};
 
 					this.dialog.loading = true;

--- a/internal/view/assets/js/page/setting.js
+++ b/internal/view/assets/js/page/setting.js
@@ -36,6 +36,10 @@ var template = `
                 Create archive by default
             </label>
             <label>
+                <input type="checkbox" v-model="appOptions.CreateEbook" @change="saveSetting">
+                Create ebook by default
+            </label>
+            <label>
                 <input type="checkbox" v-model="appOptions.MakePublic" @change="saveSetting">
                 Make archive publicly available by default
             </label>
@@ -97,6 +101,7 @@ export default {
                     ...options,
                     KeepMetadata: this.appOptions.KeepMetadata,
                     UseArchive: this.appOptions.UseArchive,
+                    CreateEbook: this.appOptions.CreateEbook,
                     MakePublic: this.appOptions.MakePublic,
                 };
             }

--- a/internal/view/content.html
+++ b/internal/view/content.html
@@ -64,12 +64,14 @@
 						ListMode = (typeof opts.config.ListMode === "boolean") ? opts.config.ListMode : false,
 						NightMode = (typeof opts.config.NightMode === "boolean") ? opts.config.NightMode : false,
 						UseArchive = (typeof opts.config.UseArchive === "boolean") ? opts.config.UseArchive : false;
+						CreateEbook = (typeof opts.config.CreateEbook === "boolean") ? opts.config.CreateEbook : false;
 
 					this.appOptions = {
 						ShowId: ShowId,
 						ListMode: ListMode,
 						NightMode: NightMode,
 						UseArchive: UseArchive,
+						CreateEbook: CreateEbook,
 					};
 
 					document.body.className = NightMode ? "night" : "";

--- a/internal/view/index.html
+++ b/internal/view/index.html
@@ -113,6 +113,7 @@
 						NightMode = (typeof opts.config.NightMode === "boolean") ? opts.config.NightMode : false,
 						KeepMetadata = (typeof opts.config.KeepMetadata === "boolean") ? opts.config.KeepMetadata : false,
 						UseArchive = (typeof opts.config.UseArchive === "boolean") ? opts.config.UseArchive : false,
+						CreateEbook = (typeof opts.config.CreateEbook === "boolean") ? opts.config.CreateEbook : false,
 						MakePublic = (typeof opts.config.MakePublic === "boolean") ? opts.config.MakePublic : false;
 
 					this.appOptions = {
@@ -123,6 +124,7 @@
 						NightMode: NightMode,
 						KeepMetadata: KeepMetadata,
 						UseArchive: UseArchive,
+						CreateEbook: CreateEbook,
 						MakePublic: MakePublic,
 					};
 

--- a/internal/webserver/handler-api.go
+++ b/internal/webserver/handler-api.go
@@ -180,6 +180,7 @@ type apiInsertBookmarkPayload struct {
 	Excerpt       string      `json:"excerpt"`
 	Tags          []model.Tag `json:"tags"`
 	CreateArchive bool        `json:"createArchive"`
+	CreateEbook   bool        `json:"createEbook"`
 	MakePublic    int         `json:"public"`
 	Async         bool        `json:"async"`
 }
@@ -189,6 +190,7 @@ type apiInsertBookmarkPayload struct {
 func newAPIInsertBookmarkPayload() *apiInsertBookmarkPayload {
 	return &apiInsertBookmarkPayload{
 		CreateArchive: false,
+		CreateEbook:   false,
 		Async:         true,
 	}
 }
@@ -213,6 +215,7 @@ func (h *Handler) ApiInsertBookmark(w http.ResponseWriter, r *http.Request, ps h
 		Tags:          payload.Tags,
 		Public:        payload.MakePublic,
 		CreateArchive: payload.CreateArchive,
+		CreateEbook:   payload.CreateEbook,
 	}
 
 	// Clean up bookmark URL


### PR DESCRIPTION
add a settings for active generate ebook by default.
# TODO:
- [x] add that to settings and work in update 
- [x] create ebook work on add new bookmark
- [x] ebook should generate after constant is available ~~(new bookmark create empty ebook right now)~~

## What is not done in this PR
- web extension and command line until we finish work on #369 

fix #720