### PR TITLE
refactor: remove afero

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,6 @@ require (
 	github.com/sethvargo/go-envconfig v0.9.0
 	github.com/shurcooL/vfsgen v0.0.0-20230704071429-0000e147ea92
 	github.com/sirupsen/logrus v1.9.3
-	github.com/spf13/afero v1.11.0
 	github.com/spf13/cobra v1.8.0
 	github.com/stretchr/testify v1.8.4
 	github.com/swaggo/files v1.0.1

--- a/go.sum
+++ b/go.sum
@@ -212,8 +212,6 @@ github.com/shurcooL/vfsgen v0.0.0-20230704071429-0000e147ea92/go.mod h1:7/OT02F6
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=
 github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
-github.com/spf13/afero v1.11.0 h1:WJQKhtpdm3v2IzqG8VMqrr6Rf3UYpEF239Jy9wNepM8=
-github.com/spf13/afero v1.11.0/go.mod h1:GH9Y3pIexgf1MTIWtNGyogA5MwRIDXGUr+hbWNoBjkY=
 github.com/spf13/cobra v1.8.0 h1:7aJaZx1B85qltLMc546zn58BxxfZdR/W22ej9CFoEf0=
 github.com/spf13/cobra v1.8.0/go.mod h1:WXLWApfZ71AjXPya3WOlMsY9yMs7YeiHhFVlvLyhcho=
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -6,15 +6,15 @@ import (
 	fp "path/filepath"
 	"time"
 
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"golang.org/x/net/context"
+
 	"github.com/go-shiori/shiori/internal/config"
 	"github.com/go-shiori/shiori/internal/database"
 	"github.com/go-shiori/shiori/internal/dependencies"
 	"github.com/go-shiori/shiori/internal/domains"
 	"github.com/go-shiori/shiori/internal/model"
-	"github.com/sirupsen/logrus"
-	"github.com/spf13/afero"
-	"github.com/spf13/cobra"
-	"golang.org/x/net/context"
 )
 
 // ShioriCmd returns the root command for shiori
@@ -103,7 +103,7 @@ func initShiori(ctx context.Context, cmd *cobra.Command) (*config.Config, *depen
 	dependencies.Domains.Auth = domains.NewAccountsDomain(dependencies)
 	dependencies.Domains.Archiver = domains.NewArchiverDomain(dependencies)
 	dependencies.Domains.Bookmarks = domains.NewBookmarksDomain(dependencies)
-	dependencies.Domains.Storage = domains.NewStorageDomain(dependencies, afero.NewBasePathFs(afero.NewOsFs(), cfg.Storage.DataDir))
+	dependencies.Domains.Storage = domains.NewStorageDomain(dependencies, cfg.Storage.DataDir)
 
 	// Workaround: Get accounts to make sure at least one is present in the database.
 	// If there's no accounts in the database, create the shiori/gopher account the legacy api

--- a/internal/core/ebook_test.go
+++ b/internal/core/ebook_test.go
@@ -6,13 +6,13 @@ import (
 	fp "path/filepath"
 	"testing"
 
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+
 	"github.com/go-shiori/shiori/internal/core"
 	"github.com/go-shiori/shiori/internal/domains"
 	"github.com/go-shiori/shiori/internal/model"
 	"github.com/go-shiori/shiori/internal/testutil"
-	"github.com/sirupsen/logrus"
-	"github.com/spf13/afero"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestGenerateEbook(t *testing.T) {
@@ -25,7 +25,7 @@ func TestGenerateEbook(t *testing.T) {
 			tempDir := t.TempDir()
 			dstDir := t.TempDir()
 
-			deps.Domains.Storage = domains.NewStorageDomain(deps, afero.NewBasePathFs(afero.NewOsFs(), dstDir))
+			deps.Domains.Storage = domains.NewStorageDomain(deps, dstDir)
 
 			mockRequest := core.ProcessRequest{
 				Bookmark: model.BookmarkDTO{
@@ -46,7 +46,7 @@ func TestGenerateEbook(t *testing.T) {
 		t.Run("ebook generate with valid BookmarkID EbookExist ImagePathExist ReturnWithHasEbookTrue", func(t *testing.T) {
 			dstDir := t.TempDir()
 
-			deps.Domains.Storage = domains.NewStorageDomain(deps, afero.NewBasePathFs(afero.NewOsFs(), dstDir))
+			deps.Domains.Storage = domains.NewStorageDomain(deps, dstDir)
 
 			bookmark := model.BookmarkDTO{
 				ID:       2,
@@ -59,8 +59,8 @@ func TestGenerateEbook(t *testing.T) {
 			}
 			// Create the thumbnail file
 			imagePath := model.GetThumbnailPath(&bookmark)
-			deps.Domains.Storage.FS().MkdirAll(fp.Dir(imagePath), os.ModePerm)
-			file, err := deps.Domains.Storage.FS().Create(imagePath)
+			deps.Domains.Storage.MkDirAll(fp.Dir(imagePath), os.ModePerm)
+			file, err := deps.Domains.Storage.Create(imagePath)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -76,7 +76,7 @@ func TestGenerateEbook(t *testing.T) {
 			tempDir := t.TempDir()
 			dstDir := t.TempDir()
 
-			deps.Domains.Storage = domains.NewStorageDomain(deps, afero.NewBasePathFs(afero.NewOsFs(), dstDir))
+			deps.Domains.Storage = domains.NewStorageDomain(deps, dstDir)
 
 			bookmark := model.BookmarkDTO{
 				ID:       3,
@@ -89,8 +89,8 @@ func TestGenerateEbook(t *testing.T) {
 			}
 			// Create the archive file
 			archivePath := model.GetArchivePath(&bookmark)
-			deps.Domains.Storage.FS().MkdirAll(fp.Dir(archivePath), os.ModePerm)
-			file, err := deps.Domains.Storage.FS().Create(archivePath)
+			deps.Domains.Storage.MkDirAll(fp.Dir(archivePath), os.ModePerm)
+			file, err := deps.Domains.Storage.Create(archivePath)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -124,7 +124,7 @@ func TestGenerateEbook(t *testing.T) {
 		t.Run("ebook exist return HasEbook true", func(t *testing.T) {
 			dstDir := t.TempDir()
 
-			deps.Domains.Storage = domains.NewStorageDomain(deps, afero.NewBasePathFs(afero.NewOsFs(), dstDir))
+			deps.Domains.Storage = domains.NewStorageDomain(deps, dstDir)
 
 			bookmark := model.BookmarkDTO{
 				ID:       1,
@@ -137,8 +137,8 @@ func TestGenerateEbook(t *testing.T) {
 			}
 			// Create the ebook file
 			ebookFilePath := model.GetEbookPath(&bookmark)
-			deps.Domains.Storage.FS().MkdirAll(fp.Dir(ebookFilePath), os.ModePerm)
-			file, err := deps.Domains.Storage.FS().Create(ebookFilePath)
+			deps.Domains.Storage.MkDirAll(fp.Dir(ebookFilePath), os.ModePerm)
+			file, err := deps.Domains.Storage.Create(ebookFilePath)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/internal/core/processing.go
+++ b/internal/core/processing.go
@@ -7,6 +7,7 @@ import (
 	"image/color"
 	"image/draw"
 	"image/jpeg"
+	_ "image/png"
 	"io"
 	"log"
 	"math"
@@ -18,14 +19,12 @@ import (
 
 	"github.com/disintegration/imaging"
 	"github.com/go-shiori/go-readability"
-	"github.com/go-shiori/shiori/internal/dependencies"
-	"github.com/go-shiori/shiori/internal/model"
 	"github.com/go-shiori/warc"
 	"github.com/pkg/errors"
 	_ "golang.org/x/image/webp"
 
-	// Add support for png
-	_ "image/png"
+	"github.com/go-shiori/shiori/internal/dependencies"
+	"github.com/go-shiori/shiori/internal/model"
 )
 
 // ProcessRequest is the request for processing bookmark.
@@ -108,7 +107,7 @@ func ProcessBookmark(deps *dependencies.Dependencies, req ProcessRequest) (book 
 		if article.Image != "" {
 			imageURLs = append(imageURLs, article.Image)
 		} else {
-			deps.Domains.Storage.FS().Remove(imgPath)
+			deps.Domains.Storage.Remove(imgPath)
 		}
 
 		if article.Favicon != "" {
@@ -128,7 +127,7 @@ func ProcessBookmark(deps *dependencies.Dependencies, req ProcessRequest) (book 
 		if err != nil && errors.Is(err, ErrNoSupportedImageType) {
 			log.Printf("%s: %s", err, imageURL)
 			if i == len(imageURLs)-1 {
-				deps.Domains.Storage.FS().Remove(imgPath)
+				deps.Domains.Storage.Remove(imgPath)
 			}
 		}
 		if err != nil {
@@ -163,7 +162,7 @@ func ProcessBookmark(deps *dependencies.Dependencies, req ProcessRequest) (book 
 		if err != nil {
 			return book, false, fmt.Errorf("failed to create temp archive: %v", err)
 		}
-		defer deps.Domains.Storage.FS().Remove(tmpFile.Name())
+		defer deps.Domains.Storage.Remove(tmpFile.Name())
 
 		archivalRequest := warc.ArchivalRequest{
 			URL:         book.URL,

--- a/internal/core/processing_test.go
+++ b/internal/core/processing_test.go
@@ -9,11 +9,12 @@ import (
 	fp "path/filepath"
 	"testing"
 
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+
 	"github.com/go-shiori/shiori/internal/core"
 	"github.com/go-shiori/shiori/internal/model"
 	"github.com/go-shiori/shiori/internal/testutil"
-	"github.com/sirupsen/logrus"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestDownloadBookImage(t *testing.T) {
@@ -24,8 +25,7 @@ func TestDownloadBookImage(t *testing.T) {
 		t.Run("fails", func(t *testing.T) {
 			// images is too small with unsupported format with a valid URL
 			imageURL := "https://github.com/go-shiori/shiori/blob/master/internal/view/assets/res/apple-touch-icon-152x152.png"
-			tempDir := t.TempDir()
-			dstPath := fp.Join(tempDir, "1")
+			dstPath := fp.Join("image", "1")
 			defer os.Remove(dstPath)
 
 			// Act
@@ -38,8 +38,7 @@ func TestDownloadBookImage(t *testing.T) {
 		t.Run("successful download image", func(t *testing.T) {
 			// Arrange
 			imageURL := "https://raw.githubusercontent.com/go-shiori/shiori/master/docs/readme/cover.png"
-			tempDir := t.TempDir()
-			dstPath := fp.Join(tempDir, "1")
+			dstPath := fp.Join("image", "1")
 			defer os.Remove(dstPath)
 
 			// Act
@@ -59,8 +58,7 @@ func TestDownloadBookImage(t *testing.T) {
 
 			// Arrange
 			imageURL := server.URL + "/medium_image.png"
-			tempDir := t.TempDir()
-			dstPath := fp.Join(tempDir, "1")
+			dstPath := fp.Join("image", "1")
 			defer os.Remove(dstPath)
 
 			// Act

--- a/internal/domains/bookmarks_test.go
+++ b/internal/domains/bookmarks_test.go
@@ -2,7 +2,11 @@ package domains_test
 
 import (
 	"context"
+	"os"
 	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
 
 	"github.com/go-shiori/shiori/internal/config"
 	"github.com/go-shiori/shiori/internal/database"
@@ -10,13 +14,11 @@ import (
 	"github.com/go-shiori/shiori/internal/domains"
 	"github.com/go-shiori/shiori/internal/model"
 	"github.com/go-shiori/shiori/internal/testutil"
-	"github.com/sirupsen/logrus"
-	"github.com/spf13/afero"
-	"github.com/stretchr/testify/require"
 )
 
 func TestBookmarkDomain(t *testing.T) {
-	fs := afero.NewMemMapFs()
+	tmpDir, err := os.MkdirTemp("", "")
+	require.NoError(t, err)
 
 	db, err := database.OpenSQLiteDatabase(context.TODO(), ":memory:")
 	require.NoError(t, err)
@@ -28,13 +30,15 @@ func TestBookmarkDomain(t *testing.T) {
 		Log:      logrus.New(),
 		Domains:  &dependencies.Domains{},
 	}
-	deps.Domains.Storage = domains.NewStorageDomain(deps, fs)
+	deps.Domains.Storage = domains.NewStorageDomain(deps, tmpDir)
 
-	fs.MkdirAll("thumb", 0755)
+	fs := deps.Domains.Storage
+
+	fs.MkDirAll("thumb", 0755)
 	fs.Create("thumb/1")
-	fs.MkdirAll("ebook", 0755)
+	fs.MkDirAll("ebook", 0755)
 	fs.Create("ebook/1.epub")
-	fs.MkdirAll("archive", 0755)
+	fs.MkDirAll("archive", 0755)
 	// TODO: write a valid archive file
 	fs.Create("archive/1")
 

--- a/internal/http/middleware/auth.go
+++ b/internal/http/middleware/auth.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/gin-gonic/gin"
+
 	"github.com/go-shiori/shiori/internal/dependencies"
 	"github.com/go-shiori/shiori/internal/http/context"
 	"github.com/go-shiori/shiori/internal/http/response"

--- a/internal/http/routes/swagger.go
+++ b/internal/http/routes/swagger.go
@@ -2,12 +2,12 @@ package routes
 
 import (
 	"github.com/gin-gonic/gin"
-	"github.com/go-shiori/shiori/internal/model"
 	"github.com/sirupsen/logrus"
 	swaggerfiles "github.com/swaggo/files"
 	ginSwagger "github.com/swaggo/gin-swagger"
 
 	_ "github.com/go-shiori/shiori/docs/swagger"
+	"github.com/go-shiori/shiori/internal/model"
 )
 
 type SwaggerAPIRoutes struct {

--- a/internal/model/domains.go
+++ b/internal/model/domains.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/go-shiori/warc"
-	"github.com/spf13/afero"
 )
 
 type BookmarksDomain interface {
@@ -30,7 +29,10 @@ type ArchiverDomain interface {
 
 type StorageDomain interface {
 	Stat(name string) (fs.FileInfo, error)
-	FS() afero.Fs
+	Create(name string) (fs.File, error)
+	Open(name string) (fs.File, error)
+	Remove(name string) error
+	MkDirAll(name string, mode os.FileMode) error
 	FileExists(path string) bool
 	DirExists(path string) bool
 	WriteData(dst string, data []byte) error

--- a/internal/testutil/shiori.go
+++ b/internal/testutil/shiori.go
@@ -5,15 +5,15 @@ import (
 	"os"
 	"testing"
 
+	"github.com/gofrs/uuid/v5"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+
 	"github.com/go-shiori/shiori/internal/config"
 	"github.com/go-shiori/shiori/internal/database"
 	"github.com/go-shiori/shiori/internal/dependencies"
 	"github.com/go-shiori/shiori/internal/domains"
 	"github.com/go-shiori/shiori/internal/model"
-	"github.com/gofrs/uuid/v5"
-	"github.com/sirupsen/logrus"
-	"github.com/spf13/afero"
-	"github.com/stretchr/testify/require"
 )
 
 func GetTestConfigurationAndDependencies(t *testing.T, ctx context.Context, logger *logrus.Logger) (*config.Config, *dependencies.Dependencies) {
@@ -39,7 +39,7 @@ func GetTestConfigurationAndDependencies(t *testing.T, ctx context.Context, logg
 	deps.Domains.Auth = domains.NewAccountsDomain(deps)
 	deps.Domains.Archiver = domains.NewArchiverDomain(deps)
 	deps.Domains.Bookmarks = domains.NewBookmarksDomain(deps)
-	deps.Domains.Storage = domains.NewStorageDomain(deps, afero.NewBasePathFs(afero.NewOsFs(), cfg.Storage.DataDir))
+	deps.Domains.Storage = domains.NewStorageDomain(deps, cfg.Storage.DataDir)
 
 	return cfg, deps
 }

--- a/internal/testutil/shiori.go
+++ b/internal/testutil/shiori.go
@@ -21,12 +21,14 @@ func GetTestConfigurationAndDependencies(t *testing.T, ctx context.Context, logg
 
 	tmp, err := os.CreateTemp("", "")
 	require.NoError(t, err)
+	t.Cleanup(func() {
+		os.Remove(tmp.Name())
+	})
 
 	cfg := config.ParseServerConfiguration(ctx, logger)
 	cfg.Http.SecretKey = []byte("test")
 
-	tempDir, err := os.MkdirTemp("", "")
-	require.NoError(t, err)
+	tempDir := t.TempDir()
 
 	db, err := database.OpenSQLiteDatabase(ctx, tmp.Name())
 	require.NoError(t, err)


### PR DESCRIPTION
Created a simple local filesystem abstrantion in the StorageDomain while removing afero, this has been done because afero was causing some problem under Windows hosts.

Fixes #822