### PR TITLE
fix: regressions and documentation from 1.5.5 upgrade

### DIFF
--- a/docs/Frequently-Asked-Question.md
+++ b/docs/Frequently-Asked-Question.md
@@ -2,21 +2,17 @@
 
 <!-- TOC -->
 
-- [Frequently asked questions](#frequently-asked-questions)
-- [General](#general)
-    - [What is this project ?](#what-is-this-project-)
-    - [How does it compare to other bookmarks manager ?](#how-does-it-compare-to-other-bookmarks-manager-)
-    - [What are the system requirements ?](#what-are-the-system-requirements-)
-    - [What is the status for this app ?](#what-is-the-status-for-this-app-)
-    - [Is this app actively maintained ?](#is-this-app-actively-maintained-)
-    - [How to make a contribution ?](#how-to-make-a-contribution-)
-    - [How to make a donation ?](#how-to-make-a-donation-)
-- [Common Issues](#common-issues)
-    - [What is the default account to login at the first time ?](#what-is-the-default-account-to-login-at-the-first-time-)
-    - [Why my old accounts can't do anything after upgrading Shiori to v1.5.0 ?](#why-my-old-accounts-cant-do-anything-after-upgrading-shiori-to-v150-)
-    - [Failed to get bookmarks: failed to fetch data: no such module: fts4 ?](#failed-to-get-bookmarks-failed-to-fetch-data-no-such-module-fts4-)
-- [Advanced](#advanced)
-    - [How to run shiori on start up ?](#how-to-run-shiori-on-start-up-)
+- [What is this project ?](#what-is-this-project-)
+- [How does it compare to other bookmarks manager ?](#how-does-it-compare-to-other-bookmarks-manager-)
+- [What are the system requirements ?](#what-are-the-system-requirements-)
+- [What is the status for this app ?](#what-is-the-status-for-this-app-)
+- [Is this app actively maintained ?](#is-this-app-actively-maintained-)
+- [How to make a contribution ?](#how-to-make-a-contribution-)
+- [How to make a donation ?](#how-to-make-a-donation-)
+- [What is the default account to login at the first time ?](#what-is-the-default-account-to-login-at-the-first-time-)
+- [Why my old accounts can't do anything after upgrading Shiori to v1.5.0 ?](#why-my-old-accounts-cant-do-anything-after-upgrading-shiori-to-v150-)
+- [`Failed to get bookmarks: failed to fetch data: no such module: fts4` ?](#failed-to-get-bookmarks-failed-to-fetch-data-no-such-module-fts4-)
+- [How to run `shiori` on start up ?](#how-to-run-shiori-on-start-up-)
 
 <!-- /TOC -->
 
@@ -90,8 +86,10 @@ If you like this project, you can donate to maintainers via:
 
 ## What is the default account to login at the first time ?
 
-The default account is `shiori` with password `gopher`.
-It is removed once another 'owner' account is created.
+A default account is created with the credentials:
+
+- Username: `shiori`
+- Password: `gopher`
 
 ## Why my old accounts can't do anything after upgrading Shiori to v1.5.0 ?
 

--- a/docs/Usage.md
+++ b/docs/Usage.md
@@ -7,9 +7,9 @@ Before using `shiori`, make sure it has been installed on your system. By defaul
   - [Search syntax](#search-syntax)
 - [Using Web Interface](#using-web-interface)
 - [Community contributions](#community-contributions)
-    - [Improved import from Pocket](#improved-import-from-pocket)
-    - [Import from Wallabag](#import-from-wallabag)
-    - [Add URL to Shiori from Android](#Add-URL-to-Shiori-from-Android)
+  - [Improved import from Pocket](#improved-import-from-pocket)
+  - [Import from Wallabag](#import-from-wallabag)
+  - [Add URL to Shiori from Android](#add-url-to-shiori-from-android)
 
 <!-- /TOC -->
 
@@ -77,10 +77,9 @@ Use "shiori [command] --help" for more information about a command.
 ```
 
 ### Search syntax
+
 With the `print` command line interface, you can use `-s` flag to submit keywords that will be searched either in url, title, excerpts or cached content.
 You may also use `-t` flag to include tags and `-e` flag to exclude tags.
-
-
 
 ## Using Web Interface
 
@@ -88,18 +87,16 @@ To access web interface run `shiori serve` or start Docker container following t
 
 ![Login screen](https://raw.githubusercontent.com/go-shiori/shiori/master/docs/screenshots/01-login.png)
 
-Since this is our first time, we don't have any account registered yet. With that said, we can use the default user to access web interface :
+Since this is our first time, we don't have any account registered yet. With that said, we can use the default user to access web interface:
 
 ```
 username: shiori
 password: gopher
 ```
 
-Once login succeed you will be able to use the web interface. To add the new account, open the settings page and add accounts as needed :
+Once login succeed you will be able to use the web interface. To add the new account, open the settings page and add accounts as needed:
 
 ![Options page](https://raw.githubusercontent.com/go-shiori/shiori/master/docs/screenshots/04-options.png)
-
-The first new account you add will become the owner and it will deactivate the "shiori:gopher" default user automatically.
 
 When searching for bookmarks, you may use `tag:tagname` to include tags and `-tag:tagname` to exclude tags in the search bar. You can also use tags dialog to do this :
 
@@ -157,8 +154,8 @@ inside the container.
     chmod +x wallabag2shiori
     ./wallabag2shiori 'path/to/to/wallabag_export_json_file'
   ```
-  
-  
+
+
 ###  Add URL to Shiori from Android
 
 

--- a/internal/cmd/serve.go
+++ b/internal/cmd/serve.go
@@ -19,6 +19,7 @@ func serveCmd() *cobra.Command {
 	cmd.Flags().StringP("address", "a", "", "Address the server listens to")
 	cmd.Flags().StringP("webroot", "r", "/", "Root path that used by server")
 	cmd.Flags().Bool("log", true, "Print out a non-standard access log")
+	cmd.Flags().Bool("serve-web-ui", true, "Serve static files from the webroot path")
 
 	return cmd
 }


### PR DESCRIPTION
- Add required flags for the `serve` command to behave properly after upgrading to `1.6.0`.
- Updated initial account references in the docs, since now it's a real account it wont be removed automatically.