### PR TITLE
Update Configuration.md to show SHIORI_HTTP_PORT deprecation.

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -30,7 +30,7 @@ Most configuration can be set directly using environment variables or flags. The
 | Environment variable                       | Default | Required | Description                                           |
 | ------------------------------------------ | ------- | -------- | ----------------------------------------------------- |
 | `SHIORI_HTTP_ENABLED`                      | True    | No       | Enable HTTP service                                   |
-| `SHIORI_HTTP_PORT`                         | 8080    | No       | Port number for the HTTP service                      |
+| `SHIORI_HTTP_PORT` (deprecated)            | 8080    | No       | (Deprecated: Use the `-p` flag for HTTP service port) |
 | `SHIORI_HTTP_ADDRESS`                      | :       | No       | Address for the HTTP service                          |
 | `SHIORI_HTTP_ROOT_PATH`                    | /       | No       | Root path for the HTTP service                        |
 | `SHIORI_HTTP_ACCESS_LOG`                   | True    | No       | Logging accessibility for HTTP requests               |
@@ -42,6 +42,7 @@ Most configuration can be set directly using environment variables or flags. The
 | `SHIORI_HTTP_IDLE_TIMEOUT`                 | 10s     | No       | Maximum amount of time to wait for the next request   |
 | `SHIORI_HTTP_DISABLE_KEEP_ALIVE`           | true    | No       | Disable HTTP keep-alive connections                   |
 | `SHIORI_HTTP_DISABLE_PARSE_MULTIPART_FORM` | true    | No       | Disable pre-parsing of multipart form                 |
+> `SHIORI_HTTP_PORT` is deprecated and will be removed in a future release. Please use the `-p` option to [specify the custom port](https://github.com/go-shiori/shiori/discussions/360) you'd like while executing the Shiori binary.
 
 ### Storage Configuration
 
@@ -71,7 +72,7 @@ To specify a custom path, set the `SHIORI_DIR` environment variable.
 
 | Environment variable       | Default | Required | Description                                     |
 | -------------------------- | ------- | -------- | ----------------------------------------------- |
-| `SHIORI_DBMS` (deprecated) | `DBMS`  | No       | Deprecated (Use environment variables for DBMS) |
+| `SHIORI_DBMS` (deprecated) | `DBMS`  | No       | (Deprecated: Use environment variables for DBMS)|
 | `SHIORI_DATABASE_URL`      | `URL`   | No       | URL for the database (required)                 |
 
 > `SHIORI_DBMS` is deprecated and will be removed in a future release. Please use `SHIORI_DATABASE_URL` instead.


### PR DESCRIPTION
## Data
- **Shiori version**: v1.5.5 
- **Database Engine**: PostgreSQL
- **Operating system**: Debian 12 Bookworm
- **CLI/Web interface/Web Extension**: Command Line Interface (CLI)

## Describe the bug / actual behavior
The configuration page has `SHIORI_HTTP_PORT` as a port you can assign as an environment variable for Linux distributions. However, even if you set the environment variable at the system level, the assignment will not work. With the introduction of the `-p` flag, it seems that Shiori will always default to 8080, no matter what you set `SHIORI_HTTP_PORT` to be as an environment variable, because the runtime variable is a higher priority. Instead you *must* set `-p` at runtime, or the hosted port will not change.

This is meant to be a simple pull request before the overall documentation revamp. 

## Proposed Change
Because other options are also deprecated, I recommend making another note in the configuration documentation about this for now in the same style as the other deprecation, as to reduce confusion for current users of Shiori. A future update for Shiori can address all deprecated configuration options and be easily found on this page for the developers.

## To Reproduce
Steps to reproduce the behavior:
1. Add an environment variable in `/etc/environment` for your Linux-based system (I used a Debian 12 Linux Container, location may slightly differ based on OS). This will make a global system variable accessible anywhere to your program, including Shiori.

`root@host# echo SHIORI_HTTP_PORT=15000 >> /etc/environment`

2. Load your change to the file into the current running system environment.  `source /etc/environment`

3. Download, compile, and run Shiori on the same system. It will tell you the web server is running the HTTP protocol on port `8080`. 

In the directory you want to download Shiori:
`git clone https://github.com/go-shiori/shiori`

Use `cd` to enter that directory and compile and run the binary:  `go build main.go`
`./main server` 

The output will look like this: 
```
INFO[2024-02-18T17:46:24Z] Starting Shiori vdev                         
INFO[2024-02-18T17:46:24Z] starting http server                          addr=":8080"
```

## Setting a custom port. 
The only way to change this behavior currently is to use the `p` option (for example, a custom port of 16000):  `./main server -p 16000` 

The output should then become:
```
INFO[2024-02-18T17:47:54Z] Starting Shiori vdev                         
INFO[2024-02-18T17:47:54Z] starting http server                          addr=":16000"
```

## Notes
This solution doesn't change the behavior of Shiori at all, it is only designed to be a temporary note in the same style as existing documentation to make addressing it easier later. 

This documentation change will make it more clear to save time for users looking on how to set environment variables on manual or Infrastructure-As-Code automated installations (Ansible), and those unfamiliar with Golang.

Alternative solutions are to remove both deprecation notes and the options from the tables, and/or make a new table for deprecated options towards the bottom of the article in case additional deprecations are expected in upcoming development. 