### PR TITLE
Add securityContext to provided Kubernetes manifest

### DIFF
--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -83,6 +83,10 @@ spec:
       labels:
         app: shiori
     spec:
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
       volumes:
       - name: app
         hostPath:


### PR DESCRIPTION
In the (currently) provided Kubernetes deployment manifest the securityContext is missing, this results in Shiori crashing with a vague "out of memory" error. This pull request adds the securityContext with the same uid and gid values as in the Docker image (1000), fixes #791.