### PR TITLE
fix: api calls using absolute urls

### DIFF
--- a/internal/view/assets/js/page/setting.js
+++ b/internal/view/assets/js/page/setting.js
@@ -107,7 +107,7 @@ export default {
 
 			this.$emit("setting-changed", options);
 			//request
-			fetch(new URL("/api/v1/auth/account", document.baseURI), {
+			fetch(new URL("api/v1/auth/account", document.baseURI), {
 				method: "PATCH",
 				body: JSON.stringify({
 					config: this.appOptions,
@@ -337,7 +337,7 @@ export default {
 				secondText: "No",
 				mainClick: () => {
 					this.dialog.loading = true;
-					fetch(`/api/accounts`, {
+					fetch(`api/accounts`, {
 						method: "delete",
 						body: JSON.stringify([account.username]),
 						headers: {


### PR DESCRIPTION
Some API calls were using an absolute path ignoring the `base href` element thus not working/pointing where it shouldn't.

Fixes #870