### PR TITLE
fix: replace --rm-dist with --clean

### DIFF
--- a/.github/workflows/_gorelease.yml
+++ b/.github/workflows/_gorelease.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           distribution: goreleaser
           version: latest
-          args: release --rm-dist ${{ env.flags }}
+          args: release --clean ${{ env.flags }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # 4.3.1


### PR DESCRIPTION
gorelease update because  `--rm-dist` deprecated
https://goreleaser.com/deprecations/#-rm-dist