### PR TITLE
Update docker-compose.yaml

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -13,8 +13,9 @@ services:
       - ".:/src/shiori"
     restart: unless-stopped
     links:
+    # Comment/Uncomment the postgres mariadb sections depending on the database you choose.
       - "postgres"
-      - "mariadb"
+      #- "mariadb"
     environment:
       SHIORI_DIR: /srv/shiori
       #SHIORI_DATABASE_URL: mysql://shiori:shiori@(mariadb)/shiori?charset=utf8mb4
@@ -27,13 +28,18 @@ services:
       POSTGRES_USER: shiori
     ports:
       - "5432:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
 
-  mariadb:
-    image: mariadb:11
-    environment:
-      MYSQL_ROOT_PASSWORD: toor
-      MYSQL_DATABASE: shiori
-      MYSQL_USER: shiori
-      MYSQL_PASSWORD: shiori
-    ports:
-      - "3306:3306"
+  #mariadb:
+    #image: mariadb:11
+    #environment:
+      #MYSQL_ROOT_PASSWORD: toor
+      #MYSQL_DATABASE: shiori
+      #MYSQL_USER: shiori
+      #MYSQL_PASSWORD: shiori
+    #ports:
+      #- "3306:3306"
+
+volumes: 
+  postgres_data: 


### PR DESCRIPTION
Howdy, I commented out the rest of the mariadb declaration, and added a comment, since the container does not need to start if postgres is the active default DB for the example. 

I also added a volume declaration for postgres to add some default persistence. Might save some new users from running a compose down and wiping their data.  

These are just opinions, feel free to accept or not. ¯\_(ツ)_/¯ 
Thanks for this project, it's pretty awesome. 