### PR TITLE
fix(ci): renamed deprecated golangci property

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,12 +2,12 @@
 
 run:
   timeout: 5m
-  skip-dirs:
-    - internal/mocks
 
 issues:
   max-issues-per-linter: 0
   max-same-issues: 0
+  exclude-dirs:
+    - internal/mocks
 
 linters-settings:
   gofmt:


### PR DESCRIPTION
Replaces the deprecated Golang-CI option `run.skip-dirs` with `issues.exclude-dirs`.