### PR TITLE
ci: increase bsd test vm cpu count

### DIFF
--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -122,7 +122,7 @@ jobs:
           version: ${{ matrix.os.version }}
           shell: bash
           memory: 1G
-          cpu_count: 1
+          cpu_count: 2
           run: |
             sudo pkg_add -u
             sudo pkg_add gmake git go


### PR DESCRIPTION
Increases the CPU count for the OpenBSD test to check if that influences the test total execution time.