### PR TITLE
fix: not checking for nil-pointer errors on migrations

### DIFF
--- a/internal/database/mysql.go
+++ b/internal/database/mysql.go
@@ -32,7 +32,7 @@ var mysqlMigrations = []migration{
 		defer tx.Rollback()
 
 		_, err = tx.Exec(`ALTER TABLE bookmark ADD COLUMN has_content BOOLEAN DEFAULT 0`)
-		if strings.Contains(err.Error(), `Duplicate column name`) {
+		if err != nil && strings.Contains(err.Error(), `Duplicate column name`) {
 			tx.Rollback()
 		} else if err != nil {
 			return fmt.Errorf("failed to add has_content column to bookmark table: %w", err)
@@ -49,7 +49,7 @@ var mysqlMigrations = []migration{
 		defer tx.Rollback()
 
 		_, err = tx.Exec(`ALTER TABLE account ADD COLUMN config JSON  NOT NULL DEFAULT '{}'`)
-		if strings.Contains(err.Error(), `Duplicate column name`) {
+		if err != nil && strings.Contains(err.Error(), `Duplicate column name`) {
 			tx.Rollback()
 		} else if err != nil {
 			return fmt.Errorf("failed to add config column to account table: %w", err)

--- a/internal/database/pg.go
+++ b/internal/database/pg.go
@@ -28,7 +28,7 @@ var postgresMigrations = []migration{
 		defer tx.Rollback()
 
 		_, err = tx.Exec(`ALTER TABLE bookmark ADD COLUMN has_content BOOLEAN DEFAULT FALSE NOT NULL`)
-		if strings.Contains(err.Error(), `column "has_content" of relation "bookmark" already exists`) {
+		if err != nil && strings.Contains(err.Error(), `column "has_content" of relation "bookmark" already exists`) {
 			tx.Rollback()
 		} else if err != nil {
 			return fmt.Errorf("failed to add has_content column to bookmark table: %w", err)
@@ -45,7 +45,7 @@ var postgresMigrations = []migration{
 		defer tx.Rollback()
 
 		_, err = tx.Exec(`ALTER TABLE account ADD COLUMN config JSONB NOT NULL DEFAULT '{}'`)
-		if strings.Contains(err.Error(), `column "config" of relation "account" already exists`) {
+		if err != nil && strings.Contains(err.Error(), `column "config" of relation "account" already exists`) {
 			tx.Rollback()
 		} else if err != nil {
 			return fmt.Errorf("failed to add config column to account table: %w", err)

--- a/internal/database/sqlite.go
+++ b/internal/database/sqlite.go
@@ -29,7 +29,7 @@ var sqliteMigrations = []migration{
 		defer tx.Rollback()
 
 		_, err = tx.Exec(`ALTER TABLE bookmark ADD COLUMN has_content BOOLEAN DEFAULT FALSE NOT NULL`)
-		if strings.Contains(err.Error(), `duplicate column name`) {
+		if err != nil && strings.Contains(err.Error(), `duplicate column name`) {
 			tx.Rollback()
 		} else if err != nil {
 			return fmt.Errorf("failed to add has_content column to bookmark table: %w", err)
@@ -46,7 +46,7 @@ var sqliteMigrations = []migration{
 		defer tx.Rollback()
 
 		_, err = tx.Exec(`ALTER TABLE account ADD COLUMN config JSON NOT NULL DEFAULT '{}'`)
-		if strings.Contains(err.Error(), `duplicate column name`) {
+		if err != nil && strings.Contains(err.Error(), `duplicate column name`) {
 			tx.Rollback()
 		} else if err != nil {
 			return fmt.Errorf("failed to add config column to account table: %w", err)


### PR DESCRIPTION
Fix potential panic by checking `err` before doing comparisons over it.

Fixes #904