### PR TITLE
fix: ensure tmp folder is present on docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,8 @@ ARG TARGETOS
 ARG TARGETVARIANT
 COPY dist/shiori_${TARGETOS}_${TARGETARCH}${TARGETVARIANT}/shiori /usr/bin/shiori
 RUN apk add --no-cache ca-certificates tzdata && \
-    chmod +x /usr/bin/shiori
+    chmod +x /usr/bin/shiori && \
+    rm -rf /tmp/*
 
 # Server image
 FROM scratch
@@ -20,6 +21,7 @@ WORKDIR ${SHIORI_DIR}
 LABEL org.opencontainers.image.source="https://github.com/go-shiori/shiori"
 LABEL maintainer="Felipe Martin <github@fmartingr.com>"
 
+COPY --from=builder /tmp /tmp
 COPY --from=builder /usr/bin/shiori /usr/bin/shiori
 COPY --from=builder /usr/share/zoneinfo /usr/share/zoneinfo
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt

--- a/internal/http/routes/api/v1/bookmarks.go
+++ b/internal/http/routes/api/v1/bookmarks.go
@@ -217,6 +217,11 @@ func (r *BookmarksAPIRoutes) updateCache(c *gin.Context) {
 			content.Close()
 
 			if err != nil {
+				r.logger.WithFields(logrus.Fields{
+					"bookmark_id": book.ID,
+					"url":         book.URL,
+					"error":       err,
+				}).Error("error downloading bookmark cache")
 				chProblem <- book.ID
 				return
 			}


### PR DESCRIPTION
- Ensures the `/tmp` folder is present in the docker container since it's required to download archives and ebooks.
- Adds a logger to the `/api/v1/bookmark/cache` endpoint to show errors to the admin.