### PR TITLE
fix: incorrect original link in archive page

### DIFF
--- a/internal/view/archive.html
+++ b/internal/view/archive.html
@@ -12,7 +12,7 @@
     <div id="shiori-archive-header" class="header">
         <p id="shiori-logo"><span>栞</span>shiori</p>
         <div class="spacer"></div>
-        <a href="$$.URL$$" target="_blank">View Original</a>
+        <a href="$$.Book.URL$$" target="_blank">View Original</a>
         $$if .Book.HasContent$$
         <a href="/bookmark/$$.Book.ID$$/content">View Readable</a>
         $$end$$


### PR DESCRIPTION
Fixes the "View original" link in the archive page.

Closes #930 