### PR TITLE
fix: add version to goreleaser archive filename

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -31,8 +31,7 @@ archives:
     name_template: >-
       {{ .ProjectName }}_
       {{- if eq .Os "darwin" }}Darwin{{- else if eq .Os "linux" }}Linux{{- else if eq .Os "windows" }}Windows{{- else }}{{ .Os }}{{ end }}_
-      {{- if eq .Arch "amd64" }}x86_64{{- else if eq .Arch "arm64" }}aarch64{{- else }}{{ .Arch }}{{ end }}
-      _{{ .Version }}
+      {{- if eq .Arch "amd64" }}x86_64{{- else if eq .Arch "arm64" }}aarch64{{- else }}{{ .Arch }}{{ end }}_{{ .Version }}
     format_overrides:
     - goos: windows
       format: zip

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -32,6 +32,7 @@ archives:
       {{ .ProjectName }}_
       {{- if eq .Os "darwin" }}Darwin{{- else if eq .Os "linux" }}Linux{{- else if eq .Os "windows" }}Windows{{- else }}{{ .Os }}{{ end }}_
       {{- if eq .Arch "amd64" }}x86_64{{- else if eq .Arch "arm64" }}aarch64{{- else }}{{ .Arch }}{{ end }}
+      _{{ .Version }}
     format_overrides:
     - goos: windows
       format: zip


### PR DESCRIPTION
This PR adds the version to the archive filename of the goreleaser dist bundles to prevent errors on releases