### PR TITLE
fix(ci): ignore nightly tags when comparing stable releases

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,6 +1,11 @@
 before:
   hooks:
     - go mod tidy
+
+git:
+  ignore_tags:
+    - "{{ if not .IsNightly }}*-rc*{{ end }}"
+
 builds:
   - binary: shiori
     env:
@@ -26,6 +31,7 @@ builds:
         goarch: arm
       - goos: windows
         goarch: arm64
+
 archives:
   - id: shiori
     name_template: >-
@@ -47,8 +53,10 @@ archives:
 
 checksum:
   name_template: 'checksums.txt'
+
 snapshot:
   name_template: "{{ incpatch .Version }}-next"
+
 changelog:
   sort: asc
   groups:
@@ -79,5 +87,6 @@ changelog:
     exclude:
       - "^deps:"
       - "^chore\\(deps\\):"
+
 release:
   prerelease: auto


### PR DESCRIPTION
This change makes goreleaser ignore release candidate tags when comparing the previous version of a stable release, generating a proper changelog instead of just the comparison with the latest RC.