### PR TITLE
feat: allow direct pdf archives

### DIFF
--- a/internal/archiver/pdf.go
+++ b/internal/archiver/pdf.go
@@ -1,0 +1,32 @@
+package archiver
+
+import (
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/go-shiori/shiori/internal/dependencies"
+	"github.com/go-shiori/shiori/internal/model"
+)
+
+type PDFArchiver struct {
+	deps *dependencies.Dependencies
+}
+
+func (a *PDFArchiver) Matches(contentType string) bool {
+	return contentType == "application/pdf"
+}
+
+func (a *PDFArchiver) Archive(content io.ReadCloser, contentType string, bookmark model.BookmarkDTO) (*model.BookmarkDTO, error) {
+	if err := a.deps.Domains.Storage.WriteFile(model.GetArchivePath(&bookmark), content.(*os.File)); err != nil {
+		return nil, fmt.Errorf("error saving pdf archive: %v", err)
+	}
+
+	return nil, nil
+}
+
+func NewPDFArchiver(deps *dependencies.Dependencies) *PDFArchiver {
+	return &PDFArchiver{
+		deps: deps,
+	}
+}

--- a/internal/archiver/warc.go
+++ b/internal/archiver/warc.go
@@ -1,0 +1,42 @@
+package archiver
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/go-shiori/shiori/internal/core"
+	"github.com/go-shiori/shiori/internal/dependencies"
+	"github.com/go-shiori/shiori/internal/model"
+)
+
+type WARCArchiver struct {
+	deps *dependencies.Dependencies
+}
+
+func (a *WARCArchiver) Matches(contentType string) bool {
+	return true
+}
+
+func (a *WARCArchiver) Archive(content io.ReadCloser, contentType string, bookmark model.BookmarkDTO) (*model.BookmarkDTO, error) {
+	processRequest := core.ProcessRequest{
+		DataDir:     a.deps.Config.Storage.DataDir,
+		Bookmark:    bookmark,
+		Content:     content,
+		ContentType: contentType,
+	}
+
+	result, isFatalErr, err := core.ProcessBookmark(a.deps, processRequest)
+	content.Close()
+
+	if err != nil && isFatalErr {
+		return nil, fmt.Errorf("failed to process: %v", err)
+	}
+
+	return &result, nil
+}
+
+func NewWARCArchiver(deps *dependencies.Dependencies) *WARCArchiver {
+	return &WARCArchiver{
+		deps: deps,
+	}
+}

--- a/internal/core/processing.go
+++ b/internal/core/processing.go
@@ -186,6 +186,8 @@ func ProcessBookmark(deps *dependencies.Dependencies, req ProcessRequest) (book 
 		}
 
 		book.HasArchive = true
+		book.ArchivePath = dstPath
+		book.Archiver = model.ArchiverWARC
 	}
 
 	return book, false, nil

--- a/internal/database/migrations/postgres/0002_bookmark_archiver.up.sql
+++ b/internal/database/migrations/postgres/0002_bookmark_archiver.up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE bookmark ADD COLUMN archiver TEXT NOT NULL DEFAULT '';
+ALTER TABLE bookmark ADD COLUMN archive_path TEXT NOT NULL DEFAULT '';

--- a/internal/database/migrations/sqlite/0004_bookmark_archiver.up.sql
+++ b/internal/database/migrations/sqlite/0004_bookmark_archiver.up.sql
@@ -1,0 +1,24 @@
+-- Create a temporary table
+CREATE TABLE IF NOT EXISTS bookmark_temp(
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    url TEXT NOT NULL,
+    title TEXT NOT NULL,
+    excerpt TEXT NOT NULL DEFAULT "",
+    author TEXT NOT NULL DEFAULT "",
+    public INTEGER NOT NULL DEFAULT 0,
+    modified TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    has_content BOOLEAN DEFAULT FALSE NOT NULL,
+    archiver TEXT NOT NULL DEFAULT "",
+    archive_path TEXT NOT NULL DEFAULT "",
+    CONSTRAINT bookmark_url_UNIQUE UNIQUE(url)
+);
+
+-- Copy data from the original table to the temporary table
+INSERT INTO bookmark_temp (id, url, title, excerpt, author, public, modified, has_content, archiver, archive_path)
+SELECT id, url, title, excerpt, author, public, modified, has_content, "warc", "" FROM bookmark;
+
+-- Drop the original table
+DROP TABLE bookmark;
+
+-- Rename the temporary table to the original table name
+ALTER TABLE bookmark_temp RENAME TO bookmark;

--- a/internal/domains/archiver.go
+++ b/internal/domains/archiver.go
@@ -29,7 +29,12 @@ func (d *ArchiverDomain) DownloadBookmarkArchive(book model.BookmarkDTO) (*model
 func (d *ArchiverDomain) ProcessBookmarkArchive(content io.ReadCloser, contentType string, book model.BookmarkDTO) (*model.BookmarkDTO, error) {
 	for _, archiver := range d.archivers {
 		if archiver.Matches(contentType) {
-			return archiver.Archive(content, contentType, book)
+			_, err := archiver.Archive(content, contentType, book)
+			if err != nil {
+				d.deps.Log.Errorf("Error archiving bookmark with archviver: %s", err)
+				continue
+			}
+			return &book, nil
 		}
 	}
 

--- a/internal/domains/archiver.go
+++ b/internal/domains/archiver.go
@@ -2,6 +2,7 @@ package domains
 
 import (
 	"fmt"
+	"io"
 	"path/filepath"
 
 	"github.com/go-shiori/shiori/internal/archiver"
@@ -22,6 +23,10 @@ func (d *ArchiverDomain) DownloadBookmarkArchive(book model.BookmarkDTO) (*model
 		return nil, fmt.Errorf("error downloading url: %s", err)
 	}
 
+	return d.ProcessBookmarkArchive(content, contentType, book)
+}
+
+func (d *ArchiverDomain) ProcessBookmarkArchive(content io.ReadCloser, contentType string, book model.BookmarkDTO) (*model.BookmarkDTO, error) {
 	for _, archiver := range d.archivers {
 		if archiver.Matches(contentType) {
 			return archiver.Archive(content, contentType, book)

--- a/internal/domains/storage.go
+++ b/internal/domains/storage.go
@@ -97,3 +97,26 @@ func (d *StorageDomain) WriteFile(dst string, tmpFile *os.File) error {
 
 	return nil
 }
+
+// WriteReader writes a reader to storage.
+func (d *StorageDomain) WriteReader(dst string, reader io.Reader) error {
+	if dst != "" && !d.DirExists(dst) {
+		err := d.fs.MkdirAll(filepath.Dir(dst), model.DataDirPerm)
+		if err != nil {
+			return fmt.Errorf("failed to create destination dir: %v", err)
+		}
+	}
+
+	dstFile, err := d.fs.Create(dst)
+	if err != nil {
+		return fmt.Errorf("failed to create destination file: %v", err)
+	}
+	defer dstFile.Close()
+
+	_, err = io.Copy(dstFile, reader)
+	if err != nil {
+		return fmt.Errorf("failed to copy file to the destination")
+	}
+
+	return nil
+}

--- a/internal/model/archiver.go
+++ b/internal/model/archiver.go
@@ -1,0 +1,8 @@
+package model
+
+import "io"
+
+type Archiver interface {
+	Archive(content io.ReadCloser, contentType string, bookmark BookmarkDTO) (*BookmarkDTO, error)
+	Matches(contentType string) bool
+}

--- a/internal/model/archiver.go
+++ b/internal/model/archiver.go
@@ -2,6 +2,11 @@ package model
 
 import "io"
 
+const (
+	ArchiverPDF  = "pdf"
+	ArchiverWARC = "warc"
+)
+
 type Archiver interface {
 	Archive(content io.ReadCloser, contentType string, bookmark BookmarkDTO) (*BookmarkDTO, error)
 	Matches(contentType string) bool

--- a/internal/model/bookmark.go
+++ b/internal/model/bookmark.go
@@ -20,6 +20,8 @@ type BookmarkDTO struct {
 	ImageURL      string `db:"image_url"     json:"imageURL"`
 	HasContent    bool   `db:"has_content"   json:"hasContent"`
 	Tags          []Tag  `json:"tags"`
+	Archiver      string `db:"archiver"      json:"archiver"`
+	ArchivePath   string `db:"archive_path"  json:"archivePath"`
 	HasArchive    bool   `json:"hasArchive"`
 	HasEbook      bool   `json:"hasEbook"`
 	CreateArchive bool   `json:"create_archive"` // TODO: migrate outside the DTO

--- a/internal/model/domains.go
+++ b/internal/model/domains.go
@@ -2,6 +2,7 @@ package model
 
 import (
 	"context"
+	"io"
 	"io/fs"
 	"os"
 	"time"
@@ -25,6 +26,7 @@ type AccountsDomain interface {
 
 type ArchiverDomain interface {
 	DownloadBookmarkArchive(book BookmarkDTO) (*BookmarkDTO, error)
+	ProcessBookmarkArchive(content io.ReadCloser, contentType string, book BookmarkDTO) (*BookmarkDTO, error)
 	GetBookmarkArchive(book *BookmarkDTO) (*warc.Archive, error)
 }
 
@@ -35,4 +37,5 @@ type StorageDomain interface {
 	DirExists(path string) bool
 	WriteData(dst string, data []byte) error
 	WriteFile(dst string, src *os.File) error
+	WriteReader(dst string, src io.Reader) error
 }

--- a/internal/webserver/handler-api-ext.go
+++ b/internal/webserver/handler-api-ext.go
@@ -1,7 +1,6 @@
 package webserver
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -10,6 +9,7 @@ import (
 	"os"
 	fp "path/filepath"
 	"strconv"
+	"strings"
 
 	"github.com/go-shiori/shiori/internal/core"
 	"github.com/go-shiori/shiori/internal/model"
@@ -59,19 +59,6 @@ func (h *Handler) ApiInsertViaExtension(w http.ResponseWriter, r *http.Request, 
 		request.Title = request.URL
 	}
 
-	// Since we are using extension, the extension might send the HTML content
-	// so no need to download it again here. However, if it's empty, it might be not HTML file
-	// so we download it here.
-	var contentType string
-	var contentBuffer io.Reader
-
-	if request.HTML == "" {
-		contentBuffer, contentType, _ = core.DownloadBookmark(request.URL)
-	} else {
-		contentType = "text/html; charset=UTF-8"
-		contentBuffer = bytes.NewBufferString(request.HTML)
-	}
-
 	// Save the bookmark with whatever we already have downloaded
 	// since we need the ID in order to download the archive
 	// Only when old bookmark is not exists.
@@ -82,38 +69,44 @@ func (h *Handler) ApiInsertViaExtension(w http.ResponseWriter, r *http.Request, 
 			return
 		}
 		book = books[0]
+	} else {
+		books, err := h.DB.SaveBookmarks(ctx, false, book)
+		if err != nil {
+			log.Printf("error saving bookmark before downloading content: %s", err)
+			return
+		}
+		book = books[0]
 	}
 
 	// At this point the web page already downloaded.
 	// Time to process it.
-	if contentBuffer != nil {
-		book.CreateArchive = true
-		request := core.ProcessRequest{
-			DataDir:     h.DataDir,
-			Bookmark:    book,
-			Content:     contentBuffer,
-			ContentType: contentType,
-		}
-
-		var isFatalErr bool
-		book, isFatalErr, err = core.ProcessBookmark(h.dependencies, request)
-
-		if tmp, ok := contentBuffer.(io.ReadCloser); ok {
-			tmp.Close()
-		}
-
-		// If we can't process or update the saved bookmark, just log it and continue on with the
-		// request.
-		if err != nil && isFatalErr {
-			log.Printf("failed to process bookmark: %v", err)
-		} else if _, err := h.DB.SaveBookmarks(ctx, false, book); err != nil {
-			log.Printf("error saving bookmark after downloading content: %s", err)
-		}
+	var result *model.BookmarkDTO
+	var errArchiver error
+	if request.HTML != "" {
+		contentType := "text/html; charset=UTF-8"
+		result, errArchiver = h.dependencies.Domains.Archiver.ProcessBookmarkArchive(io.NopCloser(strings.NewReader(request.HTML)), contentType, book)
+	} else {
+		result, errArchiver = h.dependencies.Domains.Archiver.DownloadBookmarkArchive(book)
 	}
+	if errArchiver != nil {
+		log.Printf("error downloading bookmark cache: %s", errArchiver)
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	// Save the bookmark with whatever we already have downloaded
+	// since we need the ID in order to download the archive
+	books, err := h.DB.SaveBookmarks(ctx, request.ID == 0, *result)
+	if err != nil {
+		log.Printf("error saving bookmark from extension downloading content: %s", err)
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+	book = books[0]
 
 	// Return the new bookmark
 	w.Header().Set("Content-Type", "application/json")
-	err = json.NewEncoder(w).Encode(&book)
+	err = json.NewEncoder(w).Encode(&result)
 	checkError(err)
 }
 


### PR DESCRIPTION
This pull request aims to provide PDF archives for bookmarks by directly downloading the file.

#### Notable changes
- Logic for archivers now uses the `ArchiverDomain`
  - `ArchiverDomain` initializes a list of archivers that try to match the content type, if it does, that archiver is used. If an error is raised, the next archiver is used and so on.
- Added `PDFArchiver`: Just downloads the file.
- Added `WARCArchiver` as a "catch all" (current default)
- Added database columns `bookmark.archiver` (`warc`/`pdf`) and `archive_path`.
  - Bookmark has an archive if `archive_path != ""` 

### Pending
- [ ] Migrate the `archive_path` for existing bookmarks: iterate over the bookmarks, check if the archive exists and set the path and the `archiver` to `warc`.
- [ ] Refactor EPub logic separate from the archiver

Closes #929 