### PR TITLE
fix: add `freebsd` flag to nonCGO build (#947)

### DIFF
--- a/internal/database/sqlite_noncgo.go
+++ b/internal/database/sqlite_noncgo.go
@@ -1,5 +1,5 @@
-//go:build linux || windows || darwin
-// +build linux windows darwin
+//go:build linux || windows || darwin || freebsd
+// +build linux windows darwin freebsd
 
 package database
 


### PR DESCRIPTION
Fix broken build on FreeBSD after commit 02247b215b2fa1c1c18f651561092290ed2a5058.

FIxes #947 