### PR TITLE
chore: change warning message for bun on cpus without avx2

### DIFF
--- a/scripts/styles.sh
+++ b/scripts/styles.sh
@@ -12,8 +12,7 @@ case `uname -o` in
     GNU/Linux)
     # Detect support of avx2 in linux hosts
     if ! grep -q avx2 /proc/cpuinfo; then
-        BUN="sde -chip-check-disable -- bun"
-        echo "Your CPU does not support avx2 so we use sde, for more information please look at https://github.com/oven-sh/bun/issues/762#issuecomment-1186505847"
+        echo "Your CPU does not support avx2 be sure thaty you use baseline builds of bun, for more information please look at https://github.com/oven-sh/bun/issues/67"
     fi
     ;;
 esac

--- a/scripts/styles.sh
+++ b/scripts/styles.sh
@@ -12,7 +12,7 @@ case `uname -o` in
     GNU/Linux)
     # Detect support of avx2 in linux hosts
     if ! grep -q avx2 /proc/cpuinfo; then
-        echo "Your CPU does not support avx2 be sure thaty you use baseline builds of bun, for more information please look at https://github.com/oven-sh/bun/issues/67"
+        echo "It seems that your CPU does not support AVX2, if you experience long build times (>1m) ensure that you use bun's baseline builds. More information at https://github.com/oven-sh/bun/issues/67"
     fi
     ;;
 esac


### PR DESCRIPTION
update message in `style.sh` to use baseline version instead of sde refrence to this
https://github.com/oven-sh/bun/issues/67 Thanks @fmartingr 