### PR TITLE
chore: bump compose go version to match go.mod

### DIFF
--- a/Dockerfile.compose
+++ b/Dockerfile.compose
@@ -1,4 +1,4 @@
-FROM docker.io/golang:1.21-alpine3.19
+FROM docker.io/golang:1.22.3-alpine3.19
 
 WORKDIR /src/shiori
 


### PR DESCRIPTION
Resolves https://github.com/go-shiori/shiori/issues/986 by updating Docker Go image version to match version required in `go.mod`.