### PR TITLE
docs: add mac launch agent guide

### DIFF
--- a/docs/Frequently-Asked-Question.md
+++ b/docs/Frequently-Asked-Question.md
@@ -236,3 +236,35 @@ There are several methods to run `shiori` on start up, however the most recommen
     ```sh
     systemctl enable --now shiori
     ```
+
+
+If you are using Mac, create a `local.app.shiori.plist` in `~/Libray/LaunchAgents` and use the template below. Add your own secret key and paths. The filename can be anything but it's a good practice to start it with `local`:
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>local.app.shiori</string>
+  <key>EnvironmentVariables</key>
+  <dict>
+      <key>SHIORI_HTTP_SECRET_KEY</key>
+      <string>somerandomvalue123489</string>
+  </dict>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/absolute/path/to/shiori/binary</string>
+    <string>server</string>
+    <string>--storage-directory</string>
+    <string>/absolute/path/to/shiori/storage/directory</string>
+    </array>
+  <key>RunAtLoad</key>
+  <true/>
+  <key>ServiceDescription</key>
+  <string>Shiori Bookmarking Service</string>
+</dict>
+</plist>
+```
+
+You also need to update `System Settings > General > Login Items > Allow in the background`. Next time you log in to your Mac, the Shiori server will automatically start and the Shiori login state will persist. To remove the service, delete the `plist` file from `~/Library/LaunchAgensts`.


### PR DESCRIPTION
From #999 

Instructions for Mac LaunchAgent so the Shiori server will start at login and also set the environment variable to keep the login state.

Note:
I tested on my Mac but it would be nice if someone else can also do a test to make sure.