### PR TITLE
ci: fixed goreleaser latest version binary name breaking buildx

### DIFF
--- a/.github/workflows/_gorelease.yml
+++ b/.github/workflows/_gorelease.yml
@@ -23,7 +23,7 @@ jobs:
         uses: goreleaser/goreleaser-action@286f3b13b1b49da4ac219696163fb8c1c93e1200 # 6.0.0
         with:
           distribution: goreleaser
-          version: latest
+          version: v2.4.8
           args: release --clean ${{ env.flags }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,3 +1,5 @@
+version: 2
+
 before:
   hooks:
     - go mod tidy
@@ -55,7 +57,7 @@ checksum:
   name_template: 'checksums.txt'
 
 snapshot:
-  name_template: "{{ incpatch .Version }}-next"
+  version_template: "{{ incpatch .Version }}-next"
 
 changelog:
   sort: asc

--- a/scripts/buildx.sh
+++ b/scripts/buildx.sh
@@ -17,6 +17,10 @@ if [[ -d "dist/shiori_linux_amd64_v1" ]]; then
     cp -r dist/shiori_linux_amd64_v1 dist/shiori_linux_amd64
 fi
 
+if [[ -d "dist/shiori_linux_arm64_v8.0" ]]; then
+    cp -r dist/shiori_linux_arm64_v8.0 dist/shiori_linux_arm64
+fi
+
 $CONTAINER_RUNTIME buildx build \
     -f ${CONTAINERFILE_NAME} \
     --platform=${BUILDX_PLATFORMS} \


### PR DESCRIPTION
- Use a fixed goreleaser version in CI
- Updated the `.goreleaser.yml` file, addressing the warnings.
- Rename the `arm64_v8.0` file to remove the `_v8.0` suffix which was breaking buildx builds.