### PR TITLE
feat: allow disabling swagger ui and disable it by default

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -49,13 +49,14 @@ func readDotEnv(logger *logrus.Logger) map[string]string {
 }
 
 type HttpConfig struct {
-	Enabled    bool   `env:"HTTP_ENABLED,default=True"`
-	Port       int    `env:"HTTP_PORT,default=8080"`
-	Address    string `env:"HTTP_ADDRESS,default=:"`
-	RootPath   string `env:"HTTP_ROOT_PATH,default=/"`
-	AccessLog  bool   `env:"HTTP_ACCESS_LOG,default=True"`
-	ServeWebUI bool   `env:"HTTP_SERVE_WEB_UI,default=True"`
-	SecretKey  []byte `env:"HTTP_SECRET_KEY"`
+	Enabled      bool   `env:"HTTP_ENABLED,default=True"`
+	Port         int    `env:"HTTP_PORT,default=8080"`
+	Address      string `env:"HTTP_ADDRESS,default=:"`
+	RootPath     string `env:"HTTP_ROOT_PATH,default=/"`
+	AccessLog    bool   `env:"HTTP_ACCESS_LOG,default=True"`
+	ServeWebUI   bool   `env:"HTTP_SERVE_WEB_UI,default=True"`
+	ServeSwagger bool   `env:"HTTP_SERVE_SWAGGER,default=False"`
+	SecretKey    []byte `env:"HTTP_SECRET_KEY"`
 	// Fiber Specific
 	BodyLimit                    int           `env:"HTTP_BODY_LIMIT,default=1024"`
 	ReadTimeout                  time.Duration `env:"HTTP_READ_TIMEOUT,default=10s"`

--- a/internal/http/server.go
+++ b/internal/http/server.go
@@ -61,7 +61,10 @@ func (s *HttpServer) Setup(cfg *config.Config, deps *dependencies.Dependencies) 
 	s.handle("/system", routes.NewSystemRoutes(s.logger))
 	s.handle("/bookmark", routes.NewBookmarkRoutes(s.logger, deps))
 	s.handle("/api/v1", api_v1.NewAPIRoutes(s.logger, deps, legacyRoutes.HandleLogin))
-	s.handle("/swagger", routes.NewSwaggerAPIRoutes(s.logger))
+
+	if cfg.Http.ServeSwagger {
+		s.handle("/swagger", routes.NewSwaggerAPIRoutes(s.logger))
+	}
 
 	s.http.Handler = s.engine
 	s.http.Addr = fmt.Sprintf("%s%d", cfg.Http.Address, cfg.Http.Port)


### PR DESCRIPTION
Adds a new variable to enable the Swagger UI `SHIORI_HTTP_SERVE_SWAGGER`.

Swagger UI is now disabled by default.

Closes #1025