### PR TITLE
ci: ignore build steps for dependabot

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -30,13 +30,11 @@ jobs:
     uses: ./.github/workflows/_gorelease.yml
   call-buildx:
     needs: call-gorelease
-    # only build on pull requests from the same repo for now
-    if: github.event.pull_request.head.repo.full_name == github.repository
+    if: ${{ startsWith(github.head_ref, 'dependabot/') }}
     uses: ./.github/workflows/_buildx.yml
   call-buildx-alpine:
     needs: call-gorelease
-    # only build on pull requests from the same repo for now
-    if: github.event.pull_request.head.repo.full_name == github.repository
+    if: ${{ !startsWith(github.head_ref, 'dependabot/') }}
     uses: ./.github/workflows/_buildx.yml
     with:
       tag_prefix: alpine-

--- a/.github/workflows/pull_request_closed.yml
+++ b/.github/workflows/pull_request_closed.yml
@@ -8,5 +8,6 @@ on:
 jobs:
   delete-tag:
     uses: ./.github/workflows/_delete-registry-tag.yml
+    if: github.event.pull_request.head.repo.fork == false
     with:
       tag_name: pr-${{ github.event.pull_request.number }}


### PR DESCRIPTION
- Ignore builds for dependabot (since they do not have push permissions)
- Ignore `delete-tag` step for closed pull requests coming from forks