### PR TITLE
ci: fix alpine latest not being built

### DIFF
--- a/.github/workflows/version_bump.yml
+++ b/.github/workflows/version_bump.yml
@@ -38,8 +38,6 @@ jobs:
     uses: ./.github/workflows/_buildx.yml
   call-buildx-alpine:
     needs: call-gorelease
-    # only build on pull requests from the same repo for now
-    if: github.event.pull_request.head.repo.full_name == github.repository
     uses: ./.github/workflows/_buildx.yml
     with:
       tag_prefix: alpine-


### PR DESCRIPTION
Fixes #1034 

Removes a incorrect `if` condition in the CI that prevented the Alpine images from being built on new releases.