### PR TITLE
fix: webroot not working in archive view

### DIFF
--- a/internal/view/archive.html
+++ b/internal/view/archive.html
@@ -2,10 +2,11 @@
 <html lang="en">
 
 <head>
+    <base href="$$.RootPath$$">
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>$$.Book.Title$$</title>
-    <link rel="stylesheet" href="$$.RootPath$$assets/css/archive.css" />
+    <link rel="stylesheet" href="assets/css/archive.css" />
 </head>
 
 <body class="archive">
@@ -14,10 +15,10 @@
         <div class="spacer"></div>
         <a href="$$.Book.URL$$" target="_blank">View Original</a>
         $$if .Book.HasContent$$
-        <a href="/bookmark/$$.Book.ID$$/content">View Readable</a>
+        <a href="bookmark/$$.Book.ID$$/content">View Readable</a>
         $$end$$
     </div>
-    <iframe src="/bookmark/$$.Book.ID$$/archive/file/" frameborder="0"></iframe>
+    <iframe src="bookmark/$$.Book.ID$$/archive/file/" frameborder="0"></iframe>
 </body>
 
 </html>


### PR DESCRIPTION
Setting the base URL is required for the archived page to render properly when a `--webroot` is in use.

I tested the use of the webroot by running a local nginx configured to be a reverse proxy (see configuration below) and then running shiori:

```shell
go run main.go server --webroot shiori --port 8081
```

Prior to the fix my archived page looks like this:

![Screenshot 2024-12-30 at 2 05 52 PM](https://github.com/user-attachments/assets/6a5e2f9b-4198-46f5-9a10-cae65c22fd67)

And with the fix it looks like this:

![Screenshot 2024-12-30 at 2 06 16 PM](https://github.com/user-attachments/assets/5060aae5-bb0f-44ba-ba2f-dc90b3df8c87)

I tested without `--webroot` and confirm that behavior still works.

## nginx config

I tested on MacOS by installing nginx `brew install nginx` and then editing `/opt/homebrew/etc/nginx/nginx.conf` to look like:

```nginx
worker_processes  1;

events {
    worker_connections  1024;
}

http {
    include       mime.types;
    default_type  application/octet-stream;
    sendfile        on;
    keepalive_timeout  65;

    server {
        listen       8080;
        server_name  localhost;

        location / {
            root   html;
            index  index.html index.htm;
        }

        location /shiori/ {
          proxy_pass http://localhost:8081/;
        }

        error_page   500 502 503 504  /50x.html;
        location = /50x.html {
            root   html;
        }
    }

    include servers/*;
}
```

Fixes #1042 