### PR TITLE
fix: login redirect not working properly after component refactor

### DIFF
--- a/internal/http/response/shortcuts.go
+++ b/internal/http/response/shortcuts.go
@@ -36,7 +36,7 @@ func SendInternalServerError(ctx *gin.Context) {
 
 // SendNotFound directly sends a not found response
 func RedirectToLogin(ctx *gin.Context, dst string) {
-	ctx.Redirect(http.StatusFound, "/login?dst="+dst)
+	ctx.Redirect(http.StatusFound, "/?dst="+dst)
 }
 
 func NotFound(ctx *gin.Context) {

--- a/internal/http/response/shortcuts.go
+++ b/internal/http/response/shortcuts.go
@@ -2,6 +2,7 @@ package response
 
 import (
 	"net/http"
+	"net/url"
 
 	"github.com/gin-gonic/gin"
 )
@@ -35,10 +36,17 @@ func SendInternalServerError(ctx *gin.Context) {
 }
 
 // SendNotFound directly sends a not found response
-func RedirectToLogin(ctx *gin.Context, dst string) {
-	ctx.Redirect(http.StatusFound, "/?dst="+dst)
+func RedirectToLogin(ctx *gin.Context, webroot, dst string) {
+	url := url.URL{
+		Path: webroot,
+		RawQuery: url.Values{
+			"dst": []string{dst},
+		}.Encode(),
+	}
+	ctx.Redirect(http.StatusFound, url.String())
 }
 
+// NotFound directly sends a not found response
 func NotFound(ctx *gin.Context) {
 	ctx.AbortWithStatus(http.StatusNotFound)
 }

--- a/internal/http/routes/bookmark.go
+++ b/internal/http/routes/bookmark.go
@@ -64,7 +64,7 @@ func (r *BookmarkRoutes) getBookmark(c *context.Context) (*model.BookmarkDTO, er
 	}
 
 	if bookmark.Public != 1 && !c.UserIsLogged() {
-		response.RedirectToLogin(c.Context, c.Request.URL.String())
+		response.RedirectToLogin(c.Context, r.deps.Config.Http.RootPath, c.Request.URL.String())
 		return nil, model.ErrUnauthorized
 	}
 

--- a/internal/http/routes/bookmark_test.go
+++ b/internal/http/routes/bookmark_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strconv"
 	"testing"
 
@@ -122,7 +123,7 @@ func TestBookmarkContentHandler(t *testing.T) {
 		req, _ := http.NewRequest("GET", path, nil)
 		g.ServeHTTP(w, req)
 		require.Equal(t, http.StatusFound, w.Code)
-		require.Equal(t, "/?dst="+path, w.Header().Get("Location"))
+		require.Equal(t, "/?dst="+url.QueryEscape(path), w.Header().Get("Location"))
 	})
 
 	t.Run("get existing bookmark content", func(t *testing.T) {

--- a/internal/http/routes/bookmark_test.go
+++ b/internal/http/routes/bookmark_test.go
@@ -122,7 +122,7 @@ func TestBookmarkContentHandler(t *testing.T) {
 		req, _ := http.NewRequest("GET", path, nil)
 		g.ServeHTTP(w, req)
 		require.Equal(t, http.StatusFound, w.Code)
-		require.Equal(t, "/login?dst="+path, w.Header().Get("Location"))
+		require.Equal(t, "/?dst="+path, w.Header().Get("Location"))
 	})
 
 	t.Run("get existing bookmark content", func(t *testing.T) {

--- a/internal/view/index.html
+++ b/internal/view/index.html
@@ -105,6 +105,8 @@
 								document.cookie = `token=; Path=${new URL(document.baseURI).pathname}; Expires=Thu, 01 Jan 1970 00:00:00 GMT;`;
 								this.isLoggedIn = false;
 								this.loginRequired = true;
+								this.dialog.loading = false;
+								this.dialog.visible = false;
 							}).catch(err => {
 								this.dialog.loading = false;
 								this.getErrorMessage(err).then(msg => {
@@ -155,7 +157,7 @@
 						owner: owner,
 					};
 				},
-				
+
 				onLoginSuccess() {
 					this.loadSetting();
 					this.loadAccount();
@@ -165,7 +167,7 @@
 				async validateSession() {
 					const token = localStorage.getItem("shiori-token");
 					const account = localStorage.getItem("shiori-account");
-					
+
 					if (!(token && account)) {
 						return false;
 					}
@@ -176,11 +178,11 @@
 								"Authorization": `Bearer ${token}`
 							}
 						});
-						
+
 						if (!response.ok) {
 							throw new Error('Invalid session');
 						}
-						
+
 						return true;
 					} catch (err) {
 						// Clear invalid session data
@@ -195,7 +197,7 @@
 				async checkLoginStatus() {
 					const isValid = await this.validateSession();
 					this.isLoggedIn = isValid;
-					
+
 					if (isValid) {
 						this.loadSetting();
 						this.loadAccount();


### PR DESCRIPTION
Bug introduced in #1017 

The login component was not properly handling the `dst` parameter, and the backend was redirecting to the (now non-existant) `/logjn` route.

Modified the backend to properly redirect to `/` when the user is not authenticated and added `dst` parameter support to the login component.