### PR TITLE
fix: use mysql json default as expression

### DIFF
--- a/internal/database/migrations/mysql/0001_initial_account.up.sql
+++ b/internal/database/migrations/mysql/0001_initial_account.up.sql
@@ -3,7 +3,7 @@ CREATE TABLE IF NOT EXISTS account(
 		username VARCHAR(250)   NOT NULL,
 		password BINARY(80)     NOT NULL,
 		owner    TINYINT(1)     NOT NULL DEFAULT '0',
-		config   JSON           NOT NULL DEFAULT '{}',
+		config   JSON           NOT NULL DEFAULT ('{}'),
 		PRIMARY KEY (id),
 		UNIQUE KEY account_username_UNIQUE (username))
 		CHARACTER SET utf8mb4;

--- a/internal/database/mysql.go
+++ b/internal/database/mysql.go
@@ -48,7 +48,7 @@ var mysqlMigrations = []migration{
 		}
 		defer tx.Rollback()
 
-		_, err = tx.Exec(`ALTER TABLE account ADD COLUMN config JSON  NOT NULL DEFAULT '{}'`)
+		_, err = tx.Exec(`ALTER TABLE account ADD COLUMN config JSON  NOT NULL DEFAULT ('{}')`)
 		if err != nil && strings.Contains(err.Error(), `Duplicate column name`) {
 			tx.Rollback()
 		} else if err != nil {


### PR DESCRIPTION
This pull request addresses the default value syntax for JSON columns in MySQL tables. The changes ensure consistency and correctness in the default value assignment for JSON columns.

https://dev.mysql.com/doc/refman/8.0/en/data-type-defaults.html#data-type-defaults-explicit

FIxes #1009 