### PR TITLE
fix: incorrectly set cookie's expires value in login.js

### DIFF
--- a/internal/view/assets/js/component/login.js
+++ b/internal/view/assets/js/component/login.js
@@ -130,10 +130,10 @@ export default {
 					// Save session id
 					document.cookie = `session-id=${json.message.session}; Path=${
 						new URL(document.baseURI).pathname
-					}; Expires=${json.message.expires}`;
+					}; Expires=${new Date(json.message.expires * 1000).toUTCString()}`;
 					document.cookie = `token=${json.message.token}; Path=${
 						new URL(document.baseURI).pathname
-					}; Expires=${json.message.expires}`;
+					}; Expires=${new Date(json.message.expires * 1000).toUTCString()}`;
 
 					// Save account data
 					localStorage.setItem("shiori-token", json.message.token);


### PR DESCRIPTION
When writing a cookie using document.cookie, the expires value should use the UTCString format.

https://developer.mozilla.org/en-US/docs/Web/API/Document/cookie#write_a_new_cookie

If expires is set incorrectly, the cookie will expire at the end of session and thumbnail will fail to load.