### PR TITLE
test: test all supported engines on their oldest supported releases

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,4 +1,11 @@
 #!/bin/zsh -e
 
-golint -set_exit_status ./...
-go mod tidy -v
+docker compose up -d mysql mariadb postgres
+
+export SHIORI_TEST_PG_URL="postgres://shiori:shiori@localhost:5432/shiori?sslmode=disable"
+export SHIORI_TEST_MYSQL_URL="shiori:shiori@(localhost:3306)/shiori"
+export SHIORI_TEST_MARIADB_URL="shiori:shiori@(localhost:3307)/shiori"
+
+make lint
+
+make unittest GOTESTFMT_FLAGS="-hide all"

--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       postgres:
-        image: postgres:15
+        image: postgres:13.18
         env:
           POSTGRES_PASSWORD: shiori
           POSTGRES_USER: shiori
@@ -23,7 +23,7 @@ jobs:
         ports:
         - 5432:5432
       mariadb:
-        image: mariadb:11
+        image: mariadb:10.5.27
         env:
           MYSQL_USER: shiori
           MYSQL_PASSWORD: shiori
@@ -33,6 +33,17 @@ jobs:
           --health-cmd="/usr/local/bin/healthcheck.sh --connect" --health-interval 10s --health-timeout 5s --health-retries 5
         ports:
         - 3306:3306
+      mysql:
+        image: mysql:8.0.40
+        env:
+          MYSQL_USER: shiori
+          MYSQL_PASSWORD: shiori
+          MYSQL_DATABASE: shiori
+          MYSQL_ROOT_PASSWORD: shiori
+        options: >-
+          --health-cmd="/usr/local/bin/healthcheck.sh --connect" --health-interval 10s --health-timeout 5s --health-retries 5
+        ports:
+        - 3307:3306
 
     name: Go unit tests (ubuntu-latest)
     steps:
@@ -60,6 +71,7 @@ jobs:
       env:
         SHIORI_TEST_PG_URL: "postgres://shiori:shiori@localhost:5432/shiori?sslmode=disable"
         SHIORI_TEST_MYSQL_URL: "shiori:shiori@(localhost:3306)/shiori"
+        SHIORI_TEST_MARIADB_URL: "shiori:shiori@(localhost:3307)/shiori"
         CGO_ENABLED: 1 # go test -race requires cgo
 
     - run: go build -tags osusergo,netgo -ldflags="-s -w -X main.version=$(git describe --tags) -X main.date=$(date --iso-8601=seconds)"

--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -41,7 +41,10 @@ jobs:
           MYSQL_DATABASE: shiori
           MYSQL_ROOT_PASSWORD: shiori
         options: >-
-          --health-cmd="/usr/local/bin/healthcheck.sh --connect" --health-interval 10s --health-timeout 5s --health-retries 5
+          --health-cmd="mysqladmin ping"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=3
         ports:
         - 3307:3306
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -36,7 +36,7 @@ services:
       - shiori
 
   postgres:
-    image: postgres:15
+    image: postgres:13.18
     environment:
       POSTGRES_PASSWORD: shiori
       POSTGRES_USER: shiori
@@ -44,7 +44,7 @@ services:
       - "5432:5432"
 
   mariadb:
-    image: mariadb:11
+    image: mariadb:10.5.27
     environment:
       MYSQL_ROOT_PASSWORD: toor
       MYSQL_DATABASE: shiori
@@ -52,6 +52,16 @@ services:
       MYSQL_PASSWORD: shiori
     ports:
       - "3306:3306"
+
+  mysql:
+    image: mysql:8.0.40
+    environment:
+      MYSQL_ROOT_PASSWORD: toor
+      MYSQL_DATABASE: shiori
+      MYSQL_USER: shiori
+      MYSQL_PASSWORD: shiori
+    ports:
+      - "3307:3306"
 
 volumes:
   go-mod-cache:

--- a/docs/Contribute.md
+++ b/docs/Contribute.md
@@ -57,14 +57,19 @@ In order to run the test suite, you need to have running a local instance of Mar
 If you have docker, you can do this by running the following command with the compose file provided:
 
 ```bash
-docker-compose up -d mariadb postgres
+docker-compose up -d mariadb mysql postgres
 ```
 
-After that, provide the `SHIORI_TEST_PG_URL` and `SHIORI_TEST_MYSQL_URL` environment variables with the connection string to the databases:
+After that, provide the environment variables for the unitest to connect to the database engines:
+
+- `SHIORI_TEST_MYSQL_URL` for MySQL
+- `SHIORI_TEST_MARIADB_URL` for MariaDB
+- `SHIORI_TEST_PG_URL` for PostgreSQL
 
 ```
 SHIORI_TEST_PG_URL=postgres://shiori:shiori@127.0.0.1:5432/shiori?sslmode=disable
 SHIORI_TEST_MYSQL_URL=shiori:shiori@tcp(127.0.0.1:3306)/shiori
+SHIORI_TEST_MARIADB_URL=shiori:shiori@tcp(127.0.0.1:3307)/shiori
 ```
 
 Finally, run the tests with the following command:

--- a/internal/database/mysql_test.go
+++ b/internal/database/mysql_test.go
@@ -19,43 +19,49 @@ func init() {
 	}
 }
 
-func mysqlTestDatabaseFactory(_ *testing.T, ctx context.Context) (DB, error) {
-	connString := os.Getenv("SHIORI_TEST_MYSQL_URL")
-	db, err := OpenMySQLDatabase(ctx, connString)
-	if err != nil {
-		return nil, err
-	}
-
-	var dbname string
-	err = db.withTx(ctx, func(tx *sqlx.Tx) error {
-		err := tx.QueryRow("SELECT DATABASE()").Scan(&dbname)
+func mysqlTestDatabaseFactory(envKey string) testDatabaseFactory {
+	return func(_ *testing.T, ctx context.Context) (DB, error) {
+		connString := os.Getenv(envKey)
+		db, err := OpenMySQLDatabase(ctx, connString)
 		if err != nil {
-			return err
+			return nil, err
 		}
 
-		_, err = tx.ExecContext(ctx, "DROP DATABASE IF EXISTS "+dbname)
-		if err != nil {
+		var dbname string
+		err = db.withTx(ctx, func(tx *sqlx.Tx) error {
+			err := tx.QueryRow("SELECT DATABASE()").Scan(&dbname)
+			if err != nil {
+				return err
+			}
+
+			_, err = tx.ExecContext(ctx, "DROP DATABASE IF EXISTS "+dbname)
+			if err != nil {
+				return err
+			}
+
+			_, err = tx.ExecContext(ctx, "CREATE DATABASE "+dbname)
 			return err
+		})
+		if err != nil {
+			return nil, err
 		}
 
-		_, err = tx.ExecContext(ctx, "CREATE DATABASE "+dbname)
-		return err
-	})
-	if err != nil {
-		return nil, err
-	}
+		if _, err := db.Exec("USE " + dbname); err != nil {
+			return nil, err
+		}
 
-	if _, err := db.Exec("USE " + dbname); err != nil {
-		return nil, err
-	}
+		if err = db.Migrate(context.TODO()); err != nil {
+			return nil, err
+		}
 
-	if err = db.Migrate(context.TODO()); err != nil {
-		return nil, err
+		return db, err
 	}
-
-	return db, err
 }
 
 func TestMysqlsDatabase(t *testing.T) {
-	testDatabase(t, mysqlTestDatabaseFactory)
+	testDatabase(t, mysqlTestDatabaseFactory("SHIORI_TEST_MYSQL_URL"))
+}
+
+func TestMariaDBDatabase(t *testing.T) {
+	testDatabase(t, mysqlTestDatabaseFactory("SHIORI_TEST_MARIADB_URL"))
 }


### PR DESCRIPTION
Modifies the docker compose and github workflow files to use the oldest supported database engines, adding mysql into de mix, so we can run the test suite against all of them, helping identifying database bugs earlier.

#1009 