### PR TITLE
feat: allow tag filtering and count retrieval via api

### DIFF
--- a/docs/swagger/docs.go
+++ b/docs/swagger/docs.go
@@ -417,6 +417,20 @@ const docTemplate = `{
                     "Tags"
                 ],
                 "summary": "List tags",
+                "parameters": [
+                    {
+                        "type": "boolean",
+                        "description": "Include bookmark count for each tag",
+                        "name": "with_bookmark_count",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Filter tags by bookmark ID",
+                        "name": "bookmark_id",
+                        "in": "query"
+                    }
+                ],
                 "responses": {
                     "200": {
                         "description": "OK",

--- a/docs/swagger/swagger.json
+++ b/docs/swagger/swagger.json
@@ -406,6 +406,20 @@
                     "Tags"
                 ],
                 "summary": "List tags",
+                "parameters": [
+                    {
+                        "type": "boolean",
+                        "description": "Include bookmark count for each tag",
+                        "name": "with_bookmark_count",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Filter tags by bookmark ID",
+                        "name": "bookmark_id",
+                        "in": "query"
+                    }
+                ],
                 "responses": {
                     "200": {
                         "description": "OK",

--- a/docs/swagger/swagger.yaml
+++ b/docs/swagger/swagger.yaml
@@ -441,6 +441,15 @@ paths:
   /api/v1/tags:
     get:
       description: List all tags
+      parameters:
+      - description: Include bookmark count for each tag
+        in: query
+        name: with_bookmark_count
+        type: boolean
+      - description: Filter tags by bookmark ID
+        in: query
+        name: bookmark_id
+        type: integer
       produces:
       - application/json
       responses:

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -124,7 +124,7 @@ func initShiori(ctx context.Context, cmd *cobra.Command) (*config.Config, *depen
 		account := model.AccountDTO{
 			Username: "shiori",
 			Password: "gopher",
-			Owner:    model.Ptr[bool](true),
+			Owner:    model.Ptr(true),
 		}
 
 		if _, err := dependencies.Domains().Accounts().CreateAccount(cmd.Context(), account); err != nil {

--- a/internal/database/database_tags.go
+++ b/internal/database/database_tags.go
@@ -59,7 +59,7 @@ func (db *dbbase) GetTags(ctx context.Context, opts model.DBListTagsOptions) ([]
 
 	slog.Info("GetTags query", "query", query, "args", args)
 
-	tags := []model.TagDTO{}
+	var tags []model.TagDTO
 	err := db.ReaderDB().SelectContext(ctx, &tags, query, args...)
 	if err != nil && err != sql.ErrNoRows {
 		return nil, fmt.Errorf("failed to get tags: %w", err)

--- a/internal/database/database_tags.go
+++ b/internal/database/database_tags.go
@@ -1,0 +1,69 @@
+package database
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"log/slog"
+
+	"github.com/go-shiori/shiori/internal/model"
+	"github.com/huandu/go-sqlbuilder"
+)
+
+// GetTags returns a list of tags from the database.
+// If opts.WithBookmarkCount is true, the result will include the number of bookmarks for each tag.
+// If opts.BookmarkID is not 0, the result will include only the tags for the specified bookmark.
+// If opts.OrderBy is set, the result will be ordered by the specified column.
+func (db *dbbase) GetTags(ctx context.Context, opts model.DBListTagsOptions) ([]model.TagDTO, error) {
+	sb := db.Flavor().NewSelectBuilder()
+
+	sb.Select("t.id", "t.name")
+	sb.From("tag t")
+
+	// Treat the case where we want the bookmark count and filter by bookmark ID as a special case:
+	// If we only want one of them, we can use a JOIN and GROUP BY.
+	// If we want both, we need to use a subquery to get the count of bookmarks for each tag filtered
+	// by bookmark ID.
+	if opts.WithBookmarkCount && opts.BookmarkID == 0 {
+		// Join with bookmark_tag and group by tag ID to get the count of bookmarks for each tag
+		sb.JoinWithOption(sqlbuilder.LeftJoin, "bookmark_tag bt", "bt.tag_id = t.id")
+		sb.SelectMore("COUNT(bt.tag_id) AS bookmark_count")
+		sb.GroupBy("t.id")
+	} else if opts.BookmarkID > 0 {
+		// If we want the bookmark count, we need to use a subquery to get the count of bookmarks for each tag
+		if opts.WithBookmarkCount {
+			sb.SelectMore(
+				sb.BuilderAs(
+					db.Flavor().NewSelectBuilder().Select("COUNT(bt2.tag_id)").From("bookmark_tag bt2").Where("bt2.tag_id = t.id"),
+					"bookmark_count",
+				),
+			)
+		}
+
+		// Join with bookmark_tag and filter by bookmark ID to get the tags for a specific bookmark
+		sb.JoinWithOption(sqlbuilder.RightJoin, "bookmark_tag bt",
+			sb.And(
+				"bt.tag_id = t.id",
+				sb.Equal("bt.bookmark_id", opts.BookmarkID),
+			),
+		)
+		sb.Where(sb.IsNotNull("t.id"))
+	}
+
+	if opts.OrderBy == model.DBTagOrderByTagName {
+		sb.OrderBy("t.name")
+	}
+
+	query, args := sb.Build()
+	query = db.ReaderDB().Rebind(query)
+
+	slog.Info("GetTags query", "query", query, "args", args)
+
+	tags := []model.TagDTO{}
+	err := db.ReaderDB().SelectContext(ctx, &tags, query, args...)
+	if err != nil && err != sql.ErrNoRows {
+		return nil, fmt.Errorf("failed to get tags: %w", err)
+	}
+
+	return tags, nil
+}

--- a/internal/database/database_tags.go
+++ b/internal/database/database_tags.go
@@ -59,7 +59,7 @@ func (db *dbbase) GetTags(ctx context.Context, opts model.DBListTagsOptions) ([]
 
 	slog.Info("GetTags query", "query", query, "args", args)
 
-	var tags []model.TagDTO
+	tags := []model.TagDTO{}
 	err := db.ReaderDB().SelectContext(ctx, &tags, query, args...)
 	if err != nil && err != sql.ErrNoRows {
 		return nil, fmt.Errorf("failed to get tags: %w", err)

--- a/internal/database/database_tags_test.go
+++ b/internal/database/database_tags_test.go
@@ -1,0 +1,244 @@
+package database
+
+import (
+	"context"
+	"testing"
+
+	"github.com/go-shiori/shiori/internal/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// testGetTagsFunction tests the GetTags function with various options
+func testGetTagsFunction(t *testing.T, db model.DB) {
+	ctx := context.TODO()
+
+	// Create test tags
+	tags := []model.Tag{
+		{Name: "golang"},
+		{Name: "database"},
+		{Name: "testing"},
+		{Name: "web"},
+	}
+	createdTags, err := db.CreateTags(ctx, tags...)
+	require.NoError(t, err)
+	require.Len(t, createdTags, 4)
+
+	// Map tag names to IDs for easier reference
+	tagIDsByName := make(map[string]int)
+	for _, tag := range createdTags {
+		tagIDsByName[tag.Name] = tag.ID
+	}
+
+	// Create bookmarks with different tag combinations
+	bookmarks := []model.BookmarkDTO{
+		{
+			URL:   "https://golang.org",
+			Title: "Go Language",
+			Tags: []model.TagDTO{
+				{Tag: model.Tag{Name: "golang"}},
+				{Tag: model.Tag{Name: "web"}},
+			},
+		},
+		{
+			URL:   "https://postgresql.org",
+			Title: "PostgreSQL",
+			Tags: []model.TagDTO{
+				{Tag: model.Tag{Name: "database"}},
+			},
+		},
+		{
+			URL:   "https://sqlite.org",
+			Title: "SQLite",
+			Tags: []model.TagDTO{
+				{Tag: model.Tag{Name: "database"}},
+				{Tag: model.Tag{Name: "testing"}},
+			},
+		},
+	}
+
+	// Save bookmarks
+	var savedBookmarks []model.BookmarkDTO
+	for _, bookmark := range bookmarks {
+		result, err := db.SaveBookmarks(ctx, true, bookmark)
+		require.NoError(t, err)
+		require.Len(t, result, 1)
+		savedBookmarks = append(savedBookmarks, result[0])
+	}
+
+	// Verify test data setup
+	t.Run("VerifyTestData", func(t *testing.T) {
+		// Check that all bookmarks were saved with their tags
+		for i, bookmark := range savedBookmarks {
+			assert.NotZero(t, bookmark.ID)
+			assert.Len(t, bookmark.Tags, len(bookmarks[i].Tags))
+		}
+
+		// Verify that the first bookmark has golang and web tags
+		assert.Len(t, savedBookmarks[0].Tags, 2)
+		tagNames := []string{savedBookmarks[0].Tags[0].Name, savedBookmarks[0].Tags[1].Name}
+		assert.Contains(t, tagNames, "golang")
+		assert.Contains(t, tagNames, "web")
+	})
+
+	// Test 1: Get all tags without any options
+	t.Run("GetAllTags", func(t *testing.T) {
+		fetchedTags, err := db.GetTags(ctx, model.DBListTagsOptions{})
+		require.NoError(t, err)
+
+		// Should return all 4 tags
+		assert.Len(t, fetchedTags, 4)
+
+		// Verify all tag names are present
+		tagNames := make(map[string]bool)
+		for _, tag := range fetchedTags {
+			tagNames[tag.Name] = true
+		}
+
+		for _, expectedTag := range tags {
+			assert.True(t, tagNames[expectedTag.Name], "Tag %s should be present", expectedTag.Name)
+		}
+	})
+
+	// Test 2: Get tags with bookmark count
+	t.Run("GetTagsWithBookmarkCount", func(t *testing.T) {
+		fetchedTags, err := db.GetTags(ctx, model.DBListTagsOptions{
+			WithBookmarkCount: true,
+		})
+		require.NoError(t, err)
+
+		// Should return all 4 tags
+		assert.Len(t, fetchedTags, 4)
+
+		// Create a map of tag name to bookmark count
+		tagCounts := make(map[string]int64)
+		for _, tag := range fetchedTags {
+			tagCounts[tag.Name] = tag.BookmarkCount
+		}
+
+		// Verify counts
+		assert.Equal(t, int64(1), tagCounts["golang"])
+		assert.Equal(t, int64(2), tagCounts["database"])
+		assert.Equal(t, int64(1), tagCounts["testing"])
+		assert.Equal(t, int64(1), tagCounts["web"])
+	})
+
+	// Test 3: Get tags for a specific bookmark
+	t.Run("GetTagsForBookmark", func(t *testing.T) {
+		// Get tags for the first bookmark (Go Language with golang and web tags)
+		fetchedTags, err := db.GetTags(ctx, model.DBListTagsOptions{
+			BookmarkID: savedBookmarks[0].ID,
+		})
+		require.NoError(t, err)
+
+		// Should return 2 tags
+		assert.Len(t, fetchedTags, 2)
+
+		// Verify tag names
+		tagNames := make(map[string]bool)
+		for _, tag := range fetchedTags {
+			tagNames[tag.Name] = true
+		}
+
+		assert.True(t, tagNames["golang"], "Tag 'golang' should be present")
+		assert.True(t, tagNames["web"], "Tag 'web' should be present")
+	})
+
+	// Test 4: Get tags for a specific bookmark with bookmark count
+	t.Run("GetTagsForBookmarkWithCount", func(t *testing.T) {
+		// Get tags for the third bookmark (SQLite with database and testing tags)
+		fetchedTags, err := db.GetTags(ctx, model.DBListTagsOptions{
+			BookmarkID:        savedBookmarks[2].ID,
+			WithBookmarkCount: true,
+		})
+		require.NoError(t, err)
+
+		// Should return 2 tags
+		assert.Len(t, fetchedTags, 2)
+
+		// Create a map of tag name to bookmark count
+		tagCounts := make(map[string]int64)
+		for _, tag := range fetchedTags {
+			tagCounts[tag.Name] = tag.BookmarkCount
+		}
+
+		// Verify counts - database should have 2 bookmarks, testing should have 1
+		assert.Equal(t, int64(2), tagCounts["database"])
+		assert.Equal(t, int64(1), tagCounts["testing"])
+	})
+
+	// Test 5: Get tags ordered by name
+	t.Run("GetTagsOrderedByName", func(t *testing.T) {
+		fetchedTags, err := db.GetTags(ctx, model.DBListTagsOptions{
+			OrderBy: model.DBTagOrderByTagName,
+		})
+		require.NoError(t, err)
+
+		// Should return all 4 tags in alphabetical order
+		assert.Len(t, fetchedTags, 4)
+
+		// Verify order
+		assert.Equal(t, "database", fetchedTags[0].Name)
+		assert.Equal(t, "golang", fetchedTags[1].Name)
+		assert.Equal(t, "testing", fetchedTags[2].Name)
+		assert.Equal(t, "web", fetchedTags[3].Name)
+	})
+
+	// Test 6: Get tags for a non-existent bookmark
+	t.Run("GetTagsForNonExistentBookmark", func(t *testing.T) {
+		fetchedTags, err := db.GetTags(ctx, model.DBListTagsOptions{
+			BookmarkID: 9999, // Non-existent ID
+		})
+		require.NoError(t, err)
+
+		// Should return empty result
+		assert.Empty(t, fetchedTags)
+	})
+
+	// Test 7: Get tags for a bookmark with no tags
+	t.Run("GetTagsForBookmarkWithNoTags", func(t *testing.T) {
+		// Create a bookmark with no tags
+		bookmarkWithNoTags := model.BookmarkDTO{
+			URL:   "https://example.com",
+			Title: "Example with no tags",
+		}
+
+		result, err := db.SaveBookmarks(ctx, true, bookmarkWithNoTags)
+		require.NoError(t, err)
+		require.Len(t, result, 1)
+
+		// Get tags for this bookmark
+		fetchedTags, err := db.GetTags(ctx, model.DBListTagsOptions{
+			BookmarkID: result[0].ID,
+		})
+		require.NoError(t, err)
+
+		// Should return empty result
+		assert.Empty(t, fetchedTags)
+	})
+
+	// Test 8: Get tags with combined options (order + count)
+	t.Run("GetTagsWithCombinedOptions", func(t *testing.T) {
+		fetchedTags, err := db.GetTags(ctx, model.DBListTagsOptions{
+			WithBookmarkCount: true,
+			OrderBy:           model.DBTagOrderByTagName,
+		})
+		require.NoError(t, err)
+
+		// Should return all 4 tags in alphabetical order with counts
+		assert.Len(t, fetchedTags, 4)
+
+		// Verify order and counts
+		assert.Equal(t, "database", fetchedTags[0].Name)
+		assert.Equal(t, int64(2), fetchedTags[0].BookmarkCount)
+
+		assert.Equal(t, "golang", fetchedTags[1].Name)
+		assert.Equal(t, int64(1), fetchedTags[1].BookmarkCount)
+
+		assert.Equal(t, "testing", fetchedTags[2].Name)
+		assert.Equal(t, int64(1), fetchedTags[2].BookmarkCount)
+
+		assert.Equal(t, "web", fetchedTags[3].Name)
+		assert.Equal(t, int64(1), fetchedTags[3].BookmarkCount)
+	})
+}

--- a/internal/database/mysql_test.go
+++ b/internal/database/mysql_test.go
@@ -52,7 +52,7 @@ func mysqlTestDatabaseFactory(envKey string) testDatabaseFactory {
 			return nil, err
 		}
 
-		if _, err := db.Exec("USE " + dbname); err != nil {
+		if _, err := db.ExecContext(ctx, "USE "+dbname); err != nil {
 			return nil, err
 		}
 

--- a/internal/database/pg_test.go
+++ b/internal/database/pg_test.go
@@ -25,7 +25,7 @@ func postgresqlTestDatabaseFactory(_ *testing.T, ctx context.Context) (model.DB,
 		return nil, err
 	}
 
-	_, err = db.Exec("DROP SCHEMA public CASCADE; CREATE SCHEMA public;")
+	_, err = db.ExecContext(ctx, "DROP SCHEMA public CASCADE; CREATE SCHEMA public;")
 	if err != nil {
 		return nil, err
 	}

--- a/internal/database/sqlite_noncgo.go
+++ b/internal/database/sqlite_noncgo.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/huandu/go-sqlbuilder"
 	"github.com/jmoiron/sqlx"
 
 	_ "modernc.org/sqlite"
@@ -26,8 +27,11 @@ func OpenSQLiteDatabase(ctx context.Context, databasePath string) (sqliteDB *SQL
 	}
 
 	sqliteDB = &SQLiteDatabase{
-		writer: &dbbase{rwDB},
-		reader: &dbbase{rDB},
+		dbbase: dbbase{
+			writer: rwDB,
+			reader: rDB,
+			flavor: sqlbuilder.SQLite,
+		},
 	}
 
 	if err := sqliteDB.Init(ctx); err != nil {

--- a/internal/database/sqlite_openbsd.go
+++ b/internal/database/sqlite_openbsd.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/huandu/go-sqlbuilder"
 	"github.com/jmoiron/sqlx"
 
 	_ "git.sr.ht/~emersion/go-sqlite3-fts5"
@@ -27,8 +28,11 @@ func OpenSQLiteDatabase(ctx context.Context, databasePath string) (sqliteDB *SQL
 	}
 
 	sqliteDB = &SQLiteDatabase{
-		writer: &dbbase{rwDB},
-		reader: &dbbase{rDB},
+		dbbase: dbbase{
+			writer: rwDB,
+			reader: rDB,
+			flavor: sqlbuilder.SQLite,
+		},
 	}
 
 	if err := sqliteDB.Init(ctx); err != nil {

--- a/internal/domains/tags.go
+++ b/internal/domains/tags.go
@@ -16,8 +16,8 @@ func NewTagsDomain(deps model.Dependencies) model.TagsDomain {
 	return &tagsDomain{deps: deps}
 }
 
-func (d *tagsDomain) ListTags(ctx context.Context) ([]model.TagDTO, error) {
-	tags, err := d.deps.Database().GetTags(ctx)
+func (d *tagsDomain) ListTags(ctx context.Context, opts model.ListTagsOptions) ([]model.TagDTO, error) {
+	tags, err := d.deps.Database().GetTags(ctx, model.DBListTagsOptions(opts))
 	if err != nil {
 		return nil, err
 	}

--- a/internal/http/handlers/api/v1/tags.go
+++ b/internal/http/handlers/api/v1/tags.go
@@ -15,11 +15,11 @@ import (
 // @Tags						Tags
 // @securityDefinitions.apikey	ApiKeyAuth
 // @Produce					json
-// @Param                      with_bookmark_count   query   boolean  false  "Include bookmark count for each tag"
-// @Param                      bookmark_id           query   integer  false  "Filter tags by bookmark ID"
-// @Success					200	{array}		model.TagDTO
-// @Failure					403	{object}	nil	"Authentication required"
-// @Failure					500	{object}	nil	"Internal server error"
+// @Param						with_bookmark_count	query		boolean	false	"Include bookmark count for each tag"
+// @Param						bookmark_id			query		integer	false	"Filter tags by bookmark ID"
+// @Success					200					{array}		model.TagDTO
+// @Failure					403					{object}	nil	"Authentication required"
+// @Failure					500					{object}	nil	"Internal server error"
 // @Router						/api/v1/tags [get]
 func HandleListTags(deps model.Dependencies, c model.WebContext) {
 	if err := middleware.RequireLoggedInUser(deps, c); err != nil {
@@ -94,7 +94,7 @@ func HandleGetTag(deps model.Dependencies, c model.WebContext) {
 // @Description				Create a new tag
 // @Tags						Tags
 // @securityDefinitions.apikey	ApiKeyAuth
-// @Accept					json
+// @Accept						json
 // @Produce					json
 // @Param						tag	body		model.TagDTO	true	"Tag data"
 // @Success					201	{object}	model.TagDTO
@@ -133,9 +133,9 @@ func HandleCreateTag(deps model.Dependencies, c model.WebContext) {
 // @Description				Update an existing tag
 // @Tags						Tags
 // @securityDefinitions.apikey	ApiKeyAuth
-// @Accept					json
+// @Accept						json
 // @Produce					json
-// @Param						id	path		int			true	"Tag ID"
+// @Param						id	path		int				true	"Tag ID"
 // @Param						tag	body		model.TagDTO	true	"Tag data"
 // @Success					200	{object}	model.TagDTO
 // @Failure					400	{object}	nil	"Invalid request"

--- a/internal/model/database.go
+++ b/internal/model/database.go
@@ -6,6 +6,8 @@ import (
 	"github.com/jmoiron/sqlx"
 )
 
+type DBID int
+
 // DB is interface for accessing and manipulating data in database.
 type DB interface {
 	// WriterDB is the underlying sqlx.DB
@@ -13,6 +15,9 @@ type DB interface {
 
 	// ReaderDB is the underlying sqlx.DB
 	ReaderDB() *sqlx.DB
+
+	// Flavor is the flavor of the database
+	// Flavor() sqlbuilder.Flavor
 
 	// Init initializes the database
 	Init(ctx context.Context) error
@@ -67,7 +72,7 @@ type DB interface {
 	CreateTag(ctx context.Context, tag Tag) (Tag, error)
 
 	// GetTags fetch list of tags and its frequency from database.
-	GetTags(ctx context.Context) ([]TagDTO, error)
+	GetTags(ctx context.Context, opts DBListTagsOptions) ([]TagDTO, error)
 
 	// RenameTag change the name of a tag.
 	RenameTag(ctx context.Context, id int, newName string) error
@@ -122,8 +127,15 @@ type DBListAccountsOptions struct {
 	WithPassword bool
 }
 
+type DBTagOrderBy string
+
+const (
+	DBTagOrderByTagName DBTagOrderBy = "name"
+)
+
 // DBListTagsOptions is options for fetching tags from database.
 type DBListTagsOptions struct {
 	BookmarkID        int
 	WithBookmarkCount bool
+	OrderBy           DBTagOrderBy
 }

--- a/internal/model/db.go
+++ b/internal/model/db.go
@@ -1,3 +1,0 @@
-package model
-
-type DBID int

--- a/internal/model/domains.go
+++ b/internal/model/domains.go
@@ -48,7 +48,7 @@ type StorageDomain interface {
 }
 
 type TagsDomain interface {
-	ListTags(ctx context.Context) ([]TagDTO, error)
+	ListTags(ctx context.Context, opts ListTagsOptions) ([]TagDTO, error)
 	CreateTag(ctx context.Context, tag TagDTO) (TagDTO, error)
 	GetTag(ctx context.Context, id int) (TagDTO, error)
 	UpdateTag(ctx context.Context, tag TagDTO) (TagDTO, error)

--- a/internal/model/tag.go
+++ b/internal/model/tag.go
@@ -34,3 +34,10 @@ func (t *TagDTO) ToTag() Tag {
 		Name: t.Name,
 	}
 }
+
+// ListTagsOptions is options for fetching tags from database.
+type ListTagsOptions struct {
+	BookmarkID        int
+	WithBookmarkCount bool
+	OrderBy           DBTagOrderBy
+}

--- a/internal/testutil/http.go
+++ b/internal/testutil/http.go
@@ -61,9 +61,19 @@ func WithFakeAccount(isAdmin bool) Option {
 	}
 }
 
+// WithRequestPathValue adds a path value to the request
 func WithRequestPathValue(key, value string) Option {
 	return func(c model.WebContext) {
 		c.Request().SetPathValue(key, value)
+	}
+}
+
+// WithRequestQueryParam adds a query parameter to the request
+func WithRequestQueryParam(key, value string) Option {
+	return func(c model.WebContext) {
+		q := c.Request().URL.Query()
+		q.Add(key, value)
+		c.Request().URL.RawQuery = q.Encode()
 	}
 }
 

--- a/internal/view/assets/js/page/home.js
+++ b/internal/view/assets/js/page/home.js
@@ -81,7 +81,7 @@ var template = `
         <a @click="filterTag('*')">(all tagged)</a>
         <a @click="filterTag('*', true)">(all untagged)</a>
         <a v-for="tag in tags" @click="dialogTagClicked($event, tag)">
-            #{{tag.name}}<span>{{tag.nBookmarks}}</span>
+            #{{tag.name}}<span>{{tag.bookmark_count}}</span>
         </a>
     </custom-dialog>
     <custom-dialog v-bind="dialog"/>
@@ -257,7 +257,7 @@ export default {
 
 					// Fetch tags if requested
 					if (fetchTags) {
-						return fetch(new URL("api/v1/tags", document.baseURI), {
+						return fetch(new URL("api/v1/tags?with_bookmark_count=true", document.baseURI), {
 							headers: {
 								"Content-Type": "application/json",
 								Authorization: "Bearer " + localStorage.getItem("shiori-token"),

--- a/internal/view/assets/js/page/home.js
+++ b/internal/view/assets/js/page/home.js
@@ -257,12 +257,16 @@ export default {
 
 					// Fetch tags if requested
 					if (fetchTags) {
-						return fetch(new URL("api/v1/tags?with_bookmark_count=true", document.baseURI), {
-							headers: {
-								"Content-Type": "application/json",
-								Authorization: "Bearer " + localStorage.getItem("shiori-token"),
+						return fetch(
+							new URL("api/v1/tags?with_bookmark_count=true", document.baseURI),
+							{
+								headers: {
+									"Content-Type": "application/json",
+									Authorization:
+										"Bearer " + localStorage.getItem("shiori-token"),
+								},
 							},
-						});
+						);
 					} else {
 						this.loading = false;
 						throw skipFetchTags;

--- a/internal/webserver/handler-api.go
+++ b/internal/webserver/handler-api.go
@@ -131,7 +131,9 @@ func (h *Handler) ApiGetTags(w http.ResponseWriter, r *http.Request, ps httprout
 	checkError(err)
 
 	// Fetch all tags
-	tags, err := h.DB.GetTags(ctx)
+	tags, err := h.DB.GetTags(ctx, model.DBListTagsOptions{
+		WithBookmarkCount: true,
+	})
 	checkError(err)
 
 	w.Header().Set("Content-Type", "application/json")


### PR DESCRIPTION
Added missing stuff for #658:

- Allows to retrieve the bookmark tag count on tags
- Allows to filter tags by bookmark ID
- Refactored the database logic to have common methods for all engines to reuse code with the sql builder