### PR TITLE
error handling / URL already exists

### DIFF
--- a/Dockerfile.compose
+++ b/Dockerfile.compose
@@ -3,7 +3,7 @@
 # Please do not run this Dockerfile in any environment that is not
 # a local development scenario as this is not throroughly updated nor
 # tested.
-FROM docker.io/golang:1.22-alpine
+FROM docker.io/golang:1.23.6-alpine
 
 WORKDIR /src/shiori
 

--- a/internal/model/responses.go
+++ b/internal/model/responses.go
@@ -1,0 +1,5 @@
+package model
+
+type ResponseHttpError struct {
+	Error string `json:"error"`
+}

--- a/internal/webserver/handler-api.go
+++ b/internal/webserver/handler-api.go
@@ -225,6 +225,14 @@ func (h *Handler) ApiInsertBookmark(w http.ResponseWriter, r *http.Request, ps h
 	// Save bookmark to database
 	results, err := h.DB.SaveBookmarks(ctx, true, *book)
 	if err != nil || len(results) == 0 {
+		if strings.Contains(err.Error(), "UNIQUE constraint failed: bookmark.url") {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusConflict)
+			json.NewEncoder(w).Encode(model.ResponseHttpError{Error: "URL already exists"})
+
+			return
+		}
+
 		panic(fmt.Errorf("failed to save bookmark: %v", err))
 	}
 


### PR DESCRIPTION
This is my first pull request for this project and I'm coming ambitious. Please, show some understanding.

So, I noticed that in general, adding a bookmark with a URL that already exists, results in very weird error messages.
 - in older versions, you get something like "json failed parsing", because the endpoint panics the API and the UI doesn't expect that
 - in newer versions, the UI expects such cases and it even expects error messages ! But still, all it can show is a "Unknown error occurred" because the API instead of returning a polished error it panics.

**The whole case here is that for less tech savvy people, such errors make the project look like it's broken**, while in reality I find it to be very stable and mature. Don't catch me wrong, but a tech savvy person my one day try to add again a URL that already added maybe some months ago and "JSON/UNKNOWN ERROR" is not something this person gets.

**Let's say first, that panicking is not the best option. Specially if something is so simple as that a URL is just a duplicate.** Imagine that other people may use the same deployment and they requests may fail, just because another person made a request for a duplicate URL.
For more serious errors, panicking may be optimal instead of keeping working wrongly. This is not the case here.

Changes :

 - **Since the UI expects a polished error, I return a polished error.** (http response change)
 - **Since the UI has a kind of "modeled" way of expecting an error, I added a "ResponseHttpError" type in our model, so we can all have a common base of returning an error through our HTTP responses.** (modeling change)

Thank you for your time !

P.S.
_For "ResponseHttpError" in our model, I made a file "responses" for all this in our model, there other people can add other standard responses too._ 

_Please, I don't know how to express this in our codebase, but the responses.go in the model that I added, is not for whatever responses different endpoints return, but for some standard responses like an error response in our case._ 

_I believe and I've seen that there are other standard responses coming in the way, so I guess this will be handful for everyone._ 

_Maybe, just maybe, I should had named this "standardResponses.go" or just write a comment there, but to be fair I noticed that the rest of the files had one simple word as a name, so I decided to not over-engineer by myself and see the opinions of the rest of you ! Let's over-engineer all together at least. ;)_

 

