### PR TITLE
docs: add cloudbreak.app under managed hosting

### DIFF
--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -168,8 +168,16 @@ spec:
 
 If you don't manage your own server, the below providers will host Shiori for you. None are endorsed by or affiliated with the team. Support is provided by the providers.
 
+### CloudBreak
+
+[CloudBreak](https://cloudbreak.app/products/shiori?utm_medium=referral&utm_source=shiori-docs&rby=shiori-docs) offers Shiori hosting from $12/year ($1/month).  Get $3 off with coupon `SHIORI`.
+
+<a href="https://cloudbreak.app/products/shiori?utm_medium=referral&utm_source=shiori-docs&rby=shiori-docs">
+  <img src="https://cloudbreak.app/external/subscribe-button.png" alt="Subscribe on CloudBreak" width="149" height="64">
+</a>
+
 ### PikaPods
 
-[PikaPods](https://www.pikapods.com/) offers Shiori hosting from $1/month with $5 free welcome credit. EU and US regions available. Updates are applied weekly and user data backed up daily.
+[PikaPods](https://www.pikapods.com/) offers Shiori hosting from $1.20/month with $5 free welcome credit. EU and US regions available. Updates are applied weekly and user data backed up daily.
 
 [![Run on PikaPods](https://www.pikapods.com/static/run-button.svg)](https://www.pikapods.com/pods?run=shiori)


### PR DESCRIPTION
We are now offering hosted Shiori at [CloudBreak](https://cloudbreak.app).

We'd also like to provide the same "10% of profits" arrangement we have with other projects. If there is anything that we need to handle on our end, please let us know. Otherwise, we'll be in touch as needed.

Thank you for making Shiori! We appreciate all the work that has gone into it.