### PR TITLE
Remove dead code ENV PORT

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,6 @@ RUN apk add --no-cache ca-certificates tzdata && \
 # Server image
 FROM scratch
 
-ENV PORT=8080
 ENV SHIORI_DIR=/shiori
 WORKDIR ${SHIORI_DIR}
 


### PR DESCRIPTION
`PORT` environment variable is commonly use to specify listening port. However, Shiori only accepts `-p PORT`. Remove `ENV PORT` to avoid confusion.