### PR TITLE
[PoC] Pluggable Archiver Proof-of-Concept

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,6 +74,15 @@ run-server: generate
 run-server-v2: generate
 	GIN_MODE=$(GIN_MODE) SHIORI_DEVELOPMENT=$(SHIORI_DEVELOPMENT) SHIORI_HTTP_SERVE_WEB_UI_V2=true go run main.go server --log-level debug
 
+## Runs server for local development with external archiver
+.PHONY: run-server-ext
+run-server-ext: generate
+	@echo "Starting Shiori with external archiver..."
+	@export SHIORI_EXTERNAL_ARCHIVER_ARCHIVE_COMMAND="mkdir -p /tmp/tmp-shiori && curl -o /tmp/tmp-shiori/archive_{ID} {URL}"; \
+	export SHIORI_EXTERNAL_ARCHIVER_HAS_COMMAND="test -f /tmp/tmp-shiori/archive_{ID} && echo true || echo false"; \
+	export SHIORI_EXTERNAL_ARCHIVER_GET_COMMAND="cat /tmp/tmp-shiori/archive_{ID}"; \
+	GIN_MODE=$(GIN_MODE) SHIORI_DEVELOPMENT=$(SHIORI_DEVELOPMENT) go run main.go server --log-level debug
+
 ## Generate swagger docs
 .PHONY: swagger
 swagger:

--- a/Makefile
+++ b/Makefile
@@ -81,7 +81,7 @@ run-server-ext: generate
 	@export SHIORI_EXTERNAL_ARCHIVER_ARCHIVE_COMMAND="mkdir -p /tmp/tmp-shiori && curl -o /tmp/tmp-shiori/archive_{ID} {URL}"; \
 	export SHIORI_EXTERNAL_ARCHIVER_HAS_COMMAND="test -f /tmp/tmp-shiori/archive_{ID} && echo true || echo false"; \
 	export SHIORI_EXTERNAL_ARCHIVER_GET_COMMAND="cat /tmp/tmp-shiori/archive_{ID}"; \
-	export SHIORI_EXTERNAL_ARCHIVER_DELETE_COMMAND="rm -f /tmp/tmp-shiori/archive_{ID}";
+	export SHIORI_EXTERNAL_ARCHIVER_DELETE_COMMAND="rm -f /tmp/tmp-shiori/archive_{ID}"; \
 	GIN_MODE=$(GIN_MODE) SHIORI_DEVELOPMENT=$(SHIORI_DEVELOPMENT) go run main.go server --log-level debug
 
 ## Generate swagger docs

--- a/Makefile
+++ b/Makefile
@@ -81,6 +81,7 @@ run-server-ext: generate
 	@export SHIORI_EXTERNAL_ARCHIVER_ARCHIVE_COMMAND="mkdir -p /tmp/tmp-shiori && curl -o /tmp/tmp-shiori/archive_{ID} {URL}"; \
 	export SHIORI_EXTERNAL_ARCHIVER_HAS_COMMAND="test -f /tmp/tmp-shiori/archive_{ID} && echo true || echo false"; \
 	export SHIORI_EXTERNAL_ARCHIVER_GET_COMMAND="cat /tmp/tmp-shiori/archive_{ID}"; \
+	export SHIORI_EXTERNAL_ARCHIVER_DELETE_COMMAND="rm -f /tmp/tmp-shiori/archive_{ID}";
 	GIN_MODE=$(GIN_MODE) SHIORI_DEVELOPMENT=$(SHIORI_DEVELOPMENT) go run main.go server --log-level debug
 
 ## Generate swagger docs

--- a/internal/cmd/delete.go
+++ b/internal/cmd/delete.go
@@ -70,10 +70,12 @@ func deleteHandler(cmd *cobra.Command, args []string) {
 		for _, id := range ids {
 			strID := strconv.Itoa(id)
 			imgPath := fp.Join(cfg.Storage.DataDir, "thumb", strID)
-			archivePath := fp.Join(cfg.Storage.DataDir, "archive", strID)
-
+			
 			os.Remove(imgPath)
-			os.Remove(archivePath)
+			
+			// Use ArchiverDomain to delete archive (works for both built-in and external)
+			bookmark := &model.BookmarkDTO{ID: id}
+			deps.Domains().Archiver().DeleteArchive(bookmark)
 		}
 	}
 

--- a/internal/cmd/delete.go
+++ b/internal/cmd/delete.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
+
+	"github.com/go-shiori/shiori/internal/model"
 )
 
 func deleteCmd() *cobra.Command {

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -106,7 +106,12 @@ func initShiori(ctx context.Context, cmd *cobra.Command) (*config.Config, *depen
 	dependencies := dependencies.NewDependencies(logger, db, cfg)
 	dependencies.Domains().SetAuth(domains.NewAuthDomain(dependencies))
 	dependencies.Domains().SetAccounts(domains.NewAccountsDomain(dependencies))
-	dependencies.Domains().SetArchiver(domains.NewArchiverDomain(dependencies))
+	// Initialize domains with default implementations
+	if os.Getenv("SHIORI_EXTERNAL_ARCHIVER_ARCHIVE_COMMAND") != "" {
+		dependencies.Domains().SetArchiver(domains.NewExternalArchiver(dependencies))
+	} else {
+		dependencies.Domains().SetArchiver(domains.NewBuiltInArchiver(dependencies))
+	}
 	dependencies.Domains().SetBookmarks(domains.NewBookmarksDomain(dependencies))
 	dependencies.Domains().SetStorage(domains.NewStorageDomain(dependencies, afero.NewBasePathFs(afero.NewOsFs(), cfg.Storage.DataDir)))
 	dependencies.Domains().SetTags(domains.NewTagsDomain(dependencies))

--- a/internal/core/core.go
+++ b/internal/core/core.go
@@ -1,5 +1,0 @@
-package core
-
-import "github.com/go-shiori/shiori/internal/model"
-
-var userAgent = "Shiori/" + model.BuildVersion + " (" + model.BuildCommit + ") (+https://github.com/go-shiori/shiori)"

--- a/internal/core/download.go
+++ b/internal/core/download.go
@@ -4,6 +4,8 @@ import (
 	"io"
 	"net/http"
 	"time"
+
+	"github.com/go-shiori/shiori/internal/model"
 )
 
 var httpClient = &http.Client{Timeout: time.Minute}
@@ -18,7 +20,7 @@ func DownloadBookmark(url string) (io.ReadCloser, string, error) {
 	}
 
 	// Send download request
-	req.Header.Set("User-Agent", userAgent)
+	req.Header.Set("User-Agent", model.UserAgent)
 	resp, err := httpClient.Do(req)
 	if err != nil {
 		return nil, "", err

--- a/internal/core/processing.go
+++ b/internal/core/processing.go
@@ -19,7 +19,6 @@ import (
 	"github.com/disintegration/imaging"
 	"github.com/go-shiori/go-readability"
 	"github.com/go-shiori/shiori/internal/model"
-	"github.com/go-shiori/warc"
 	"github.com/pkg/errors"
 	_ "golang.org/x/image/webp"
 
@@ -161,29 +160,16 @@ func ProcessBookmark(deps model.Dependencies, req ProcessRequest) (book model.Bo
 
 	// If needed, create offline archive as well
 	if book.CreateArchive {
-		tmpFile, err := os.CreateTemp("", "archive")
-		if err != nil {
-			return book, false, fmt.Errorf("failed to create temp archive: %v", err)
-		}
-		defer os.Remove(tmpFile.Name())
-
-		archivalRequest := warc.ArchivalRequest{
-			URL:         book.URL,
-			Reader:      archivalInput,
+		archivalRequest := model.ArchivalRequest{
+			Bookmark:    &book,
 			ContentType: contentType,
 			UserAgent:   userAgent,
 			LogEnabled:  req.LogArchival,
 		}
 
-		err = warc.NewArchive(archivalRequest, tmpFile.Name())
+		err = deps.Domains().Archiver().ArchiveBookmark(archivalRequest)
 		if err != nil {
 			return book, false, fmt.Errorf("failed to create archive: %v", err)
-		}
-
-		dstPath := model.GetArchivePath(&book)
-		err = deps.Domains().Storage().WriteFile(dstPath, tmpFile)
-		if err != nil {
-			return book, false, fmt.Errorf("failed move archive to destination `: %v", err)
 		}
 
 		book.HasArchive = true

--- a/internal/core/processing.go
+++ b/internal/core/processing.go
@@ -160,14 +160,7 @@ func ProcessBookmark(deps model.Dependencies, req ProcessRequest) (book model.Bo
 
 	// If needed, create offline archive as well
 	if book.CreateArchive {
-		archivalRequest := model.ArchivalRequest{
-			Bookmark:    &book,
-			ContentType: contentType,
-			UserAgent:   userAgent,
-			LogEnabled:  req.LogArchival,
-		}
-
-		err = deps.Domains().Archiver().ArchiveBookmark(archivalRequest)
+		err = deps.Domains().Archiver().ArchiveBookmark(&book, req.LogArchival)
 		if err != nil {
 			return book, false, fmt.Errorf("failed to create archive: %v", err)
 		}

--- a/internal/domains/archiver.go
+++ b/internal/domains/archiver.go
@@ -14,25 +14,17 @@ type ArchiverDomain struct {
 	deps *dependencies.Dependencies
 }
 
-func (d *ArchiverDomain) ArchiveBookmark(req model.ArchivalRequest) error {
+func (d *ArchiverDomain) ArchiveBookmark(book *model.BookmarkDTO, logEnabled bool) error {
 	tmpFile, err := os.CreateTemp("", "archive")
 	if err != nil {
 		return fmt.Errorf("failed to create temp archive: %v", err)
 	}
 	defer os.Remove(tmpFile.Name())
 
-	// Use default user agent if not provided
-	userAgent := req.UserAgent
-	if userAgent == "" {
-		userAgent = "Shiori/1.0" // Default user agent
-	}
-
-	// The Reader field is left nil, so warc.NewArchive will download the content
 	archivalRequest := warc.ArchivalRequest{
-		URL:         req.Bookmark.URL,
-		ContentType: req.ContentType,
-		UserAgent:   userAgent,
-		LogEnabled:  req.LogEnabled,
+		URL:         book.URL,
+		UserAgent:   model.UserAgent,
+		LogEnabled:  logEnabled,
 	}
 
 	err = warc.NewArchive(archivalRequest, tmpFile.Name())
@@ -41,7 +33,7 @@ func (d *ArchiverDomain) ArchiveBookmark(req model.ArchivalRequest) error {
 	}
 
 	// Construct the destination path using the BookmarkID
-	dstPath := model.GetArchivePath(req.Bookmark)
+	dstPath := model.GetArchivePath(book)
 
 	err = d.deps.Domains().Storage().WriteFile(dstPath, tmpFile)
 	if err != nil {

--- a/internal/domains/archiver.go
+++ b/internal/domains/archiver.go
@@ -2,9 +2,9 @@ package domains
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 
-	"github.com/go-shiori/shiori/internal/core"
 	"github.com/go-shiori/shiori/internal/dependencies"
 	"github.com/go-shiori/shiori/internal/model"
 	"github.com/go-shiori/warc"
@@ -14,27 +14,41 @@ type ArchiverDomain struct {
 	deps *dependencies.Dependencies
 }
 
-func (d *ArchiverDomain) DownloadBookmarkArchive(book model.BookmarkDTO) (*model.BookmarkDTO, error) {
-	content, contentType, err := core.DownloadBookmark(book.URL)
+func (d *ArchiverDomain) ArchiveBookmark(req model.ArchivalRequest) error {
+	tmpFile, err := os.CreateTemp("", "archive")
 	if err != nil {
-		return nil, fmt.Errorf("error downloading url: %s", err)
+		return fmt.Errorf("failed to create temp archive: %v", err)
+	}
+	defer os.Remove(tmpFile.Name())
+
+	// Use default user agent if not provided
+	userAgent := req.UserAgent
+	if userAgent == "" {
+		userAgent = "Shiori/1.0" // Default user agent
 	}
 
-	processRequest := core.ProcessRequest{
-		DataDir:     d.deps.Config().Storage.DataDir,
-		Bookmark:    book,
-		Content:     content,
-		ContentType: contentType,
+	// The Reader field is left nil, so warc.NewArchive will download the content
+	archivalRequest := warc.ArchivalRequest{
+		URL:         req.Bookmark.URL,
+		ContentType: req.ContentType,
+		UserAgent:   userAgent,
+		LogEnabled:  req.LogEnabled,
 	}
 
-	result, isFatalErr, err := core.ProcessBookmark(d.deps, processRequest)
-	content.Close()
-
-	if err != nil && isFatalErr {
-		return nil, fmt.Errorf("failed to process: %v", err)
+	err = warc.NewArchive(archivalRequest, tmpFile.Name())
+	if err != nil {
+		return fmt.Errorf("failed to create archive: %v", err)
 	}
 
-	return &result, nil
+	// Construct the destination path using the BookmarkID
+	dstPath := model.GetArchivePath(req.Bookmark)
+
+	err = d.deps.Domains().Storage().WriteFile(dstPath, tmpFile)
+	if err != nil {
+		return fmt.Errorf("failed to move archive to destination: %v", err)
+	}
+
+	return nil
 }
 
 func (d *ArchiverDomain) GetBookmarkArchive(book *model.BookmarkDTO) (*warc.Archive, error) {

--- a/internal/domains/archiver.go
+++ b/internal/domains/archiver.go
@@ -43,6 +43,11 @@ func (d *ArchiverDomain) ArchiveBookmark(book *model.BookmarkDTO, logEnabled boo
 	return nil
 }
 
+func (d *ArchiverDomain) HasArchive(book *model.BookmarkDTO) bool {
+	archivePath := model.GetArchivePath(book)
+	return d.deps.Domains().Storage().FileExists(archivePath)
+}
+
 func (d *ArchiverDomain) GetBookmarkArchive(book *model.BookmarkDTO) (*warc.Archive, error) {
 	archivePath := model.GetArchivePath(book)
 

--- a/internal/domains/archiver_builtin.go
+++ b/internal/domains/archiver_builtin.go
@@ -59,6 +59,21 @@ func (d *BuiltInArchiver) GetBookmarkArchive(book *model.BookmarkDTO) (model.Arc
 	return warc.Open(filepath.Join(d.deps.Config().Storage.DataDir, archivePath))
 }
 
+func (d *BuiltInArchiver) DeleteArchive(book *model.BookmarkDTO) error {
+	archivePath := model.GetArchivePath(book)
+	if !d.deps.Domains().Storage().FileExists(archivePath) {
+		return nil // No archive to delete
+	}
+
+	// Delete the archive file using the storage filesystem
+	err := d.deps.Domains().Storage().FS().Remove(archivePath)
+	if err != nil {
+		return fmt.Errorf("failed to delete archive: %v", err)
+	}
+
+	return nil
+}
+
 func NewBuiltInArchiver(deps *dependencies.Dependencies) *BuiltInArchiver {
 	return &BuiltInArchiver{
 		deps: deps,

--- a/internal/domains/archiver_builtin.go
+++ b/internal/domains/archiver_builtin.go
@@ -48,7 +48,7 @@ func (d *BuiltInArchiver) HasArchive(book *model.BookmarkDTO) bool {
 	return d.deps.Domains().Storage().FileExists(archivePath)
 }
 
-func (d *BuiltInArchiver) GetBookmarkArchive(book *model.BookmarkDTO) (*warc.Archive, error) {
+func (d *BuiltInArchiver) GetBookmarkArchive(book *model.BookmarkDTO) (model.Archive, error) {
 	archivePath := model.GetArchivePath(book)
 
 	if !d.deps.Domains().Storage().FileExists(archivePath) {

--- a/internal/domains/archiver_builtin.go
+++ b/internal/domains/archiver_builtin.go
@@ -10,11 +10,11 @@ import (
 	"github.com/go-shiori/warc"
 )
 
-type ArchiverDomain struct {
+type BuiltInArchiver struct {
 	deps *dependencies.Dependencies
 }
 
-func (d *ArchiverDomain) ArchiveBookmark(book *model.BookmarkDTO, logEnabled bool) error {
+func (d *BuiltInArchiver) ArchiveBookmark(book *model.BookmarkDTO, logEnabled bool) error {
 	tmpFile, err := os.CreateTemp("", "archive")
 	if err != nil {
 		return fmt.Errorf("failed to create temp archive: %v", err)
@@ -43,12 +43,12 @@ func (d *ArchiverDomain) ArchiveBookmark(book *model.BookmarkDTO, logEnabled boo
 	return nil
 }
 
-func (d *ArchiverDomain) HasArchive(book *model.BookmarkDTO) bool {
+func (d *BuiltInArchiver) HasArchive(book *model.BookmarkDTO) bool {
 	archivePath := model.GetArchivePath(book)
 	return d.deps.Domains().Storage().FileExists(archivePath)
 }
 
-func (d *ArchiverDomain) GetBookmarkArchive(book *model.BookmarkDTO) (*warc.Archive, error) {
+func (d *BuiltInArchiver) GetBookmarkArchive(book *model.BookmarkDTO) (*warc.Archive, error) {
 	archivePath := model.GetArchivePath(book)
 
 	if !d.deps.Domains().Storage().FileExists(archivePath) {
@@ -59,8 +59,8 @@ func (d *ArchiverDomain) GetBookmarkArchive(book *model.BookmarkDTO) (*warc.Arch
 	return warc.Open(filepath.Join(d.deps.Config().Storage.DataDir, archivePath))
 }
 
-func NewArchiverDomain(deps *dependencies.Dependencies) *ArchiverDomain {
-	return &ArchiverDomain{
+func NewBuiltInArchiver(deps *dependencies.Dependencies) *BuiltInArchiver {
+	return &BuiltInArchiver{
 		deps: deps,
 	}
 }

--- a/internal/domains/archiver_external.go
+++ b/internal/domains/archiver_external.go
@@ -1,6 +1,7 @@
 package domains
 
 import (
+	"bytes"
 	"fmt"
 	"os"
 	"os/exec"
@@ -8,7 +9,7 @@ import (
 
 	"github.com/go-shiori/shiori/internal/dependencies"
 	"github.com/go-shiori/shiori/internal/model"
-	"github.com/go-shiori/warc"
+	"github.com/sirupsen/logrus"
 )
 
 // ExternalArchiver implements the ArchiverDomain interface using external shell commands
@@ -25,18 +26,56 @@ func (d *ExternalArchiver) ArchiveBookmark(book *model.BookmarkDTO, logEnabled b
 	// Replace placeholders in the command
 	archiveCmd = strings.ReplaceAll(archiveCmd, "{URL}", book.URL)
 	archiveCmd = strings.ReplaceAll(archiveCmd, "{ID}", fmt.Sprintf("%d", book.ID))
-	archiveCmd = strings.ReplaceAll(archiveCmd, "{DATA_DIR}", d.deps.Config().Storage.DataDir)
+
+	// Log the command being executed
+	logger := d.deps.Logger()
+	logger.WithFields(logrus.Fields{
+		"bookmark_id": book.ID,
+		"url":        book.URL,
+		"command":    archiveCmd,
+	}).Debug("External archiver: executing archive command")
 
 	// Execute the command
 	cmd := exec.Command("sh", "-c", archiveCmd)
+	
+	// Capture stderr for logging
+	var stderrBuf bytes.Buffer
+	cmd.Stderr = &stderrBuf
+	
 	if logEnabled {
 		cmd.Stdout = os.Stdout
 		cmd.Stderr = os.Stderr
 	}
 
 	if err := cmd.Run(); err != nil {
+		stderrOutput := strings.TrimSpace(stderrBuf.String())
+		if stderrOutput != "" {
+			logger.WithFields(logrus.Fields{
+				"bookmark_id": book.ID,
+				"error":      err,
+				"stderr":     stderrOutput,
+			}).Error("External archiver: archive command failed")
+		} else {
+			logger.WithFields(logrus.Fields{
+				"bookmark_id": book.ID,
+				"error":      err,
+			}).Error("External archiver: archive command failed")
+		}
 		return fmt.Errorf("failed to execute archive command: %v", err)
 	}
+
+	// Log stderr output if there was any
+	stderrOutput := strings.TrimSpace(stderrBuf.String())
+	if stderrOutput != "" {
+		logger.WithFields(logrus.Fields{
+			"bookmark_id": book.ID,
+			"stderr":     stderrOutput,
+		}).Debug("External archiver: archive command stderr output")
+	}
+
+	logger.WithFields(logrus.Fields{
+		"bookmark_id": book.ID,
+	}).Debug("External archiver: successfully archived bookmark")
 
 	return nil
 }
@@ -49,20 +88,58 @@ func (d *ExternalArchiver) HasArchive(book *model.BookmarkDTO) bool {
 
 	// Replace placeholders in the command
 	hasCmd = strings.ReplaceAll(hasCmd, "{ID}", fmt.Sprintf("%d", book.ID))
-	hasCmd = strings.ReplaceAll(hasCmd, "{DATA_DIR}", d.deps.Config().Storage.DataDir)
+
+	// Log the command being executed
+	logger := d.deps.Logger()
+	logger.WithFields(logrus.Fields{
+		"bookmark_id": book.ID,
+		"command":    hasCmd,
+	}).Debug("External archiver: executing has archive command")
 
 	// Execute the command
 	cmd := exec.Command("sh", "-c", hasCmd)
+	
+	// Capture stderr for logging
+	var stderrBuf bytes.Buffer
+	cmd.Stderr = &stderrBuf
+	
 	output, err := cmd.Output()
 	if err != nil {
+		stderrOutput := strings.TrimSpace(stderrBuf.String())
+		if stderrOutput != "" {
+			logger.WithFields(logrus.Fields{
+				"bookmark_id": book.ID,
+				"error":      err,
+				"stderr":     stderrOutput,
+			}).Debug("External archiver: has archive command failed")
+		} else {
+			logger.WithFields(logrus.Fields{
+				"bookmark_id": book.ID,
+				"error":      err,
+			}).Debug("External archiver: has archive command failed")
+		}
 		return false
 	}
 
-	// Check if the output indicates the archive exists
-	return strings.TrimSpace(string(output)) == "true"
+	// Log stderr output if there was any
+	stderrOutput := strings.TrimSpace(stderrBuf.String())
+	if stderrOutput != "" {
+		logger.WithFields(logrus.Fields{
+			"bookmark_id": book.ID,
+			"stderr":     stderrOutput,
+		}).Debug("External archiver: has archive command stderr output")
+	}
+
+	hasArchive := strings.TrimSpace(string(output)) == "true"
+	logger.WithFields(logrus.Fields{
+		"bookmark_id": book.ID,
+		"has_archive": hasArchive,
+	}).Debug("External archiver: has archive result")
+
+	return hasArchive
 }
 
-func (d *ExternalArchiver) GetBookmarkArchive(book *model.BookmarkDTO) (*warc.Archive, error) {
+func (d *ExternalArchiver) GetBookmarkArchive(book *model.BookmarkDTO) (model.Archive, error) {
 	getCmd := os.Getenv("SHIORI_EXTERNAL_ARCHIVER_GET_COMMAND")
 	if getCmd == "" {
 		return nil, fmt.Errorf("SHIORI_EXTERNAL_ARCHIVER_GET_COMMAND environment variable is not set")
@@ -70,22 +147,65 @@ func (d *ExternalArchiver) GetBookmarkArchive(book *model.BookmarkDTO) (*warc.Ar
 
 	// Replace placeholders in the command
 	getCmd = strings.ReplaceAll(getCmd, "{ID}", fmt.Sprintf("%d", book.ID))
-	getCmd = strings.ReplaceAll(getCmd, "{DATA_DIR}", d.deps.Config().Storage.DataDir)
 
-	// Execute the command to get the archive path
+	// Log the command being executed
+	logger := d.deps.Logger()
+	logger.WithFields(logrus.Fields{
+		"bookmark_id": book.ID,
+		"command":    getCmd,
+	}).Debug("External archiver: executing get archive command")
+
+	// Execute the command to get the archive contents
 	cmd := exec.Command("sh", "-c", getCmd)
+	
+	// Capture stderr for logging
+	var stderrBuf bytes.Buffer
+	cmd.Stderr = &stderrBuf
+	
 	output, err := cmd.Output()
 	if err != nil {
+		stderrOutput := strings.TrimSpace(stderrBuf.String())
+		if stderrOutput != "" {
+			logger.WithFields(logrus.Fields{
+				"bookmark_id": book.ID,
+				"error":      err,
+				"stderr":     stderrOutput,
+			}).Error("External archiver: get archive command failed")
+		} else {
+			logger.WithFields(logrus.Fields{
+				"bookmark_id": book.ID,
+				"error":      err,
+			}).Error("External archiver: get archive command failed")
+		}
 		return nil, fmt.Errorf("failed to execute get command: %v", err)
 	}
 
-	archivePath := strings.TrimSpace(string(output))
-	if archivePath == "" {
-		return nil, fmt.Errorf("archive path is empty")
+	// Log stderr output if there was any
+	stderrOutput := strings.TrimSpace(stderrBuf.String())
+	if stderrOutput != "" {
+		logger.WithFields(logrus.Fields{
+			"bookmark_id": book.ID,
+			"stderr":     stderrOutput,
+		}).Debug("External archiver: get archive command stderr output")
 	}
 
-	// Open the archive file
-	return warc.Open(archivePath)
+	// Check if the output is empty
+	archiveContent := strings.TrimSpace(string(output))
+	if archiveContent == "" {
+		logger.WithFields(logrus.Fields{
+			"bookmark_id": book.ID,
+		}).Error("External archiver: archive content is empty")
+		return nil, fmt.Errorf("archive content is empty")
+	}
+
+	// Log successful retrieval
+	logger.WithFields(logrus.Fields{
+		"bookmark_id":     book.ID,
+		"content_length": len(archiveContent),
+	}).Debug("External archiver: successfully retrieved archive content")
+
+	// Create a SingleFileArchive with the content
+	return model.NewSingleFileArchive([]byte(archiveContent)), nil
 }
 
 func NewExternalArchiver(deps *dependencies.Dependencies) *ExternalArchiver {

--- a/internal/domains/archiver_external.go
+++ b/internal/domains/archiver_external.go
@@ -1,0 +1,95 @@
+package domains
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/go-shiori/shiori/internal/dependencies"
+	"github.com/go-shiori/shiori/internal/model"
+	"github.com/go-shiori/warc"
+)
+
+// ExternalArchiver implements the ArchiverDomain interface using external shell commands
+type ExternalArchiver struct {
+	deps *dependencies.Dependencies
+}
+
+func (d *ExternalArchiver) ArchiveBookmark(book *model.BookmarkDTO, logEnabled bool) error {
+	archiveCmd := os.Getenv("SHIORI_EXTERNAL_ARCHIVER_ARCHIVE_COMMAND")
+	if archiveCmd == "" {
+		return fmt.Errorf("SHIORI_EXTERNAL_ARCHIVER_ARCHIVE_COMMAND environment variable is not set")
+	}
+
+	// Replace placeholders in the command
+	archiveCmd = strings.ReplaceAll(archiveCmd, "{URL}", book.URL)
+	archiveCmd = strings.ReplaceAll(archiveCmd, "{ID}", fmt.Sprintf("%d", book.ID))
+	archiveCmd = strings.ReplaceAll(archiveCmd, "{DATA_DIR}", d.deps.Config().Storage.DataDir)
+
+	// Execute the command
+	cmd := exec.Command("sh", "-c", archiveCmd)
+	if logEnabled {
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+	}
+
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("failed to execute archive command: %v", err)
+	}
+
+	return nil
+}
+
+func (d *ExternalArchiver) HasArchive(book *model.BookmarkDTO) bool {
+	hasCmd := os.Getenv("SHIORI_EXTERNAL_ARCHIVER_HAS_COMMAND")
+	if hasCmd == "" {
+		return false
+	}
+
+	// Replace placeholders in the command
+	hasCmd = strings.ReplaceAll(hasCmd, "{ID}", fmt.Sprintf("%d", book.ID))
+	hasCmd = strings.ReplaceAll(hasCmd, "{DATA_DIR}", d.deps.Config().Storage.DataDir)
+
+	// Execute the command
+	cmd := exec.Command("sh", "-c", hasCmd)
+	output, err := cmd.Output()
+	if err != nil {
+		return false
+	}
+
+	// Check if the output indicates the archive exists
+	return strings.TrimSpace(string(output)) == "true"
+}
+
+func (d *ExternalArchiver) GetBookmarkArchive(book *model.BookmarkDTO) (*warc.Archive, error) {
+	getCmd := os.Getenv("SHIORI_EXTERNAL_ARCHIVER_GET_COMMAND")
+	if getCmd == "" {
+		return nil, fmt.Errorf("SHIORI_EXTERNAL_ARCHIVER_GET_COMMAND environment variable is not set")
+	}
+
+	// Replace placeholders in the command
+	getCmd = strings.ReplaceAll(getCmd, "{ID}", fmt.Sprintf("%d", book.ID))
+	getCmd = strings.ReplaceAll(getCmd, "{DATA_DIR}", d.deps.Config().Storage.DataDir)
+
+	// Execute the command to get the archive path
+	cmd := exec.Command("sh", "-c", getCmd)
+	output, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("failed to execute get command: %v", err)
+	}
+
+	archivePath := strings.TrimSpace(string(output))
+	if archivePath == "" {
+		return nil, fmt.Errorf("archive path is empty")
+	}
+
+	// Open the archive file
+	return warc.Open(archivePath)
+}
+
+func NewExternalArchiver(deps *dependencies.Dependencies) *ExternalArchiver {
+	return &ExternalArchiver{
+		deps: deps,
+	}
+}

--- a/internal/domains/archiver_external.go
+++ b/internal/domains/archiver_external.go
@@ -208,6 +208,67 @@ func (d *ExternalArchiver) GetBookmarkArchive(book *model.BookmarkDTO) (model.Ar
 	return model.NewSingleFileArchive([]byte(archiveContent)), nil
 }
 
+func (d *ExternalArchiver) DeleteArchive(book *model.BookmarkDTO) error {
+	deleteCmd := os.Getenv("SHIORI_EXTERNAL_ARCHIVER_DELETE_COMMAND")
+	if deleteCmd == "" {
+		// If no delete command is configured, try to delete from /tmp/tmp-shiori
+		archivePath := fmt.Sprintf("/tmp/tmp-shiori/archive_%d", book.ID)
+		if err := os.Remove(archivePath); err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("failed to delete external archive: %v", err)
+		}
+		return nil
+	}
+
+	// Replace placeholders in the command
+	deleteCmd = strings.ReplaceAll(deleteCmd, "{ID}", fmt.Sprintf("%d", book.ID))
+
+	// Log the command being executed
+	logger := d.deps.Logger()
+	logger.WithFields(logrus.Fields{
+		"bookmark_id": book.ID,
+		"command":    deleteCmd,
+	}).Debug("External archiver: executing delete archive command")
+
+	// Execute the command
+	cmd := exec.Command("sh", "-c", deleteCmd)
+	
+	// Capture stderr for logging
+	var stderrBuf bytes.Buffer
+	cmd.Stderr = &stderrBuf
+	
+	if err := cmd.Run(); err != nil {
+		stderrOutput := strings.TrimSpace(stderrBuf.String())
+		if stderrOutput != "" {
+			logger.WithFields(logrus.Fields{
+				"bookmark_id": book.ID,
+				"error":      err,
+				"stderr":     stderrOutput,
+			}).Error("External archiver: delete archive command failed")
+		} else {
+			logger.WithFields(logrus.Fields{
+				"bookmark_id": book.ID,
+				"error":      err,
+			}).Error("External archiver: delete archive command failed")
+		}
+		return fmt.Errorf("failed to execute delete command: %v", err)
+	}
+
+	// Log stderr output if there was any
+	stderrOutput := strings.TrimSpace(stderrBuf.String())
+	if stderrOutput != "" {
+		logger.WithFields(logrus.Fields{
+			"bookmark_id": book.ID,
+			"stderr":     stderrOutput,
+		}).Debug("External archiver: delete archive command stderr output")
+	}
+
+	logger.WithFields(logrus.Fields{
+		"bookmark_id": book.ID,
+	}).Debug("External archiver: successfully deleted archive")
+
+	return nil
+}
+
 func NewExternalArchiver(deps *dependencies.Dependencies) *ExternalArchiver {
 	return &ExternalArchiver{
 		deps: deps,

--- a/internal/domains/bookmarks.go
+++ b/internal/domains/bookmarks.go
@@ -17,11 +17,6 @@ func (d *BookmarksDomain) HasEbook(b *model.BookmarkDTO) bool {
 	return d.deps.Domains().Storage().FileExists(ebookPath)
 }
 
-func (d *BookmarksDomain) HasArchive(b *model.BookmarkDTO) bool {
-	archivePath := model.GetArchivePath(b)
-	return d.deps.Domains().Storage().FileExists(archivePath)
-}
-
 func (d *BookmarksDomain) HasThumbnail(b *model.BookmarkDTO) bool {
 	thumbnailPath := model.GetThumbnailPath(b)
 	return d.deps.Domains().Storage().FileExists(thumbnailPath)
@@ -39,7 +34,7 @@ func (d *BookmarksDomain) GetBookmark(ctx context.Context, id model.DBID) (*mode
 
 	// Check if it has ebook and archive.
 	bookmark.HasEbook = d.HasEbook(&bookmark)
-	bookmark.HasArchive = d.HasArchive(&bookmark)
+	bookmark.HasArchive = d.deps.Domains().Archiver().HasArchive(&bookmark)
 
 	return &bookmark, nil
 }
@@ -57,7 +52,7 @@ func (d *BookmarksDomain) GetBookmarks(ctx context.Context, ids []int) ([]model.
 
 		// Check if it has ebook and archive
 		bookmark.HasEbook = d.HasEbook(&bookmark)
-		bookmark.HasArchive = d.HasArchive(&bookmark)
+		bookmark.HasArchive = d.deps.Domains().Archiver().HasArchive(&bookmark)
 		bookmarks = append(bookmarks, bookmark)
 	}
 	return bookmarks, nil

--- a/internal/domains/bookmarks_test.go
+++ b/internal/domains/bookmarks_test.go
@@ -30,7 +30,7 @@ func TestBookmarkDomain(t *testing.T) {
 	// TODO: write a valid archive file
 	fs.Create("archive/1")
 
-	archiverDomain := domains.NewArchiverDomain(deps)
+	archiverDomain := domains.NewBuiltInArchiver(deps)
 	bookmarksDomain := domains.NewBookmarksDomain(deps)
 
 	t.Run("HasEbook", func(t *testing.T) {

--- a/internal/domains/bookmarks_test.go
+++ b/internal/domains/bookmarks_test.go
@@ -30,31 +30,33 @@ func TestBookmarkDomain(t *testing.T) {
 	// TODO: write a valid archive file
 	fs.Create("archive/1")
 
-	domain := domains.NewBookmarksDomain(deps)
+	archiverDomain := domains.NewArchiverDomain(deps)
+	bookmarksDomain := domains.NewBookmarksDomain(deps)
+
 	t.Run("HasEbook", func(t *testing.T) {
 		t.Run("Yes", func(t *testing.T) {
-			require.True(t, domain.HasEbook(&model.BookmarkDTO{ID: 1}))
+			require.True(t, bookmarksDomain.HasEbook(&model.BookmarkDTO{ID: 1}))
 		})
 		t.Run("No", func(t *testing.T) {
-			require.False(t, domain.HasEbook(&model.BookmarkDTO{ID: 2}))
+			require.False(t, bookmarksDomain.HasEbook(&model.BookmarkDTO{ID: 2}))
 		})
 	})
 
 	t.Run("HasArchive", func(t *testing.T) {
 		t.Run("Yes", func(t *testing.T) {
-			require.True(t, domain.HasArchive(&model.BookmarkDTO{ID: 1}))
+			require.True(t, archiverDomain.HasArchive(&model.BookmarkDTO{ID: 1}))
 		})
 		t.Run("No", func(t *testing.T) {
-			require.False(t, domain.HasArchive(&model.BookmarkDTO{ID: 2}))
+			require.False(t, archiverDomain.HasArchive(&model.BookmarkDTO{ID: 2}))
 		})
 	})
 
 	t.Run("HasThumbnail", func(t *testing.T) {
 		t.Run("Yes", func(t *testing.T) {
-			require.True(t, domain.HasThumbnail(&model.BookmarkDTO{ID: 1}))
+			require.True(t, bookmarksDomain.HasThumbnail(&model.BookmarkDTO{ID: 1}))
 		})
 		t.Run("No", func(t *testing.T) {
-			require.False(t, domain.HasThumbnail(&model.BookmarkDTO{ID: 2}))
+			require.False(t, bookmarksDomain.HasThumbnail(&model.BookmarkDTO{ID: 2}))
 		})
 	})
 
@@ -62,7 +64,7 @@ func TestBookmarkDomain(t *testing.T) {
 		t.Run("Success", func(t *testing.T) {
 			_, err := deps.Database().SaveBookmarks(context.TODO(), true, *testutil.GetValidBookmark())
 			require.NoError(t, err)
-			bookmark, err := domain.GetBookmark(context.Background(), 1)
+			bookmark, err := bookmarksDomain.GetBookmark(context.Background(), 1)
 			require.NoError(t, err)
 			require.Equal(t, 1, bookmark.ID)
 
@@ -72,7 +74,7 @@ func TestBookmarkDomain(t *testing.T) {
 		})
 
 		t.Run("NotFound", func(t *testing.T) {
-			bookmark, err := domain.GetBookmark(context.Background(), 999)
+			bookmark, err := bookmarksDomain.GetBookmark(context.Background(), 999)
 			require.Error(t, err)
 			require.Nil(t, bookmark)
 			require.Equal(t, model.ErrBookmarkNotFound, err)
@@ -82,7 +84,7 @@ func TestBookmarkDomain(t *testing.T) {
 			// Create a new context with a timeout to force an error
 			cancelCtx, cancel := context.WithCancel(context.Background())
 			cancel() // Cancel immediately to force error
-			bookmark, err := domain.GetBookmark(cancelCtx, 1)
+			bookmark, err := bookmarksDomain.GetBookmark(cancelCtx, 1)
 			require.Error(t, err)
 			require.Nil(t, bookmark)
 			require.Contains(t, err.Error(), "failed to get bookmark")
@@ -102,7 +104,7 @@ func TestBookmarkDomain(t *testing.T) {
 			require.NoError(t, err)
 
 			// Test getting multiple bookmarks
-			bookmarks, err := domain.GetBookmarks(context.Background(), []int{1, 2})
+			bookmarks, err := bookmarksDomain.GetBookmarks(context.Background(), []int{1, 2})
 			require.NoError(t, err)
 			require.Len(t, bookmarks, 2)
 
@@ -118,7 +120,7 @@ func TestBookmarkDomain(t *testing.T) {
 
 		t.Run("PartialResults", func(t *testing.T) {
 			// Test with a mix of existing and non-existing IDs
-			bookmarks, err := domain.GetBookmarks(context.Background(), []int{1, 999})
+			bookmarks, err := bookmarksDomain.GetBookmarks(context.Background(), []int{1, 999})
 			require.NoError(t, err)
 			require.Len(t, bookmarks, 1)
 			assert.Equal(t, 1, bookmarks[0].ID)
@@ -126,7 +128,7 @@ func TestBookmarkDomain(t *testing.T) {
 
 		t.Run("EmptyResults", func(t *testing.T) {
 			// Test with non-existing IDs
-			bookmarks, err := domain.GetBookmarks(context.Background(), []int{998, 999})
+			bookmarks, err := bookmarksDomain.GetBookmarks(context.Background(), []int{998, 999})
 			require.NoError(t, err)
 			require.Len(t, bookmarks, 0)
 		})
@@ -135,7 +137,7 @@ func TestBookmarkDomain(t *testing.T) {
 			// Create a new context with a timeout to force an error
 			cancelCtx, cancel := context.WithCancel(context.Background())
 			cancel() // Cancel immediately to force error
-			bookmarks, err := domain.GetBookmarks(cancelCtx, []int{1})
+			bookmarks, err := bookmarksDomain.GetBookmarks(cancelCtx, []int{1})
 			require.Error(t, err)
 			require.Nil(t, bookmarks)
 			require.Contains(t, err.Error(), "failed to get bookmark")

--- a/internal/http/handlers/bookmark.go
+++ b/internal/http/handlers/bookmark.go
@@ -63,7 +63,7 @@ func HandleBookmarkArchive(deps model.Dependencies, c model.WebContext) {
 		return
 	}
 
-	if !deps.Domains().Bookmarks().HasArchive(bookmark) {
+	if !deps.Domains().Archiver().HasArchive(bookmark) {
 		response.NotFound(c)
 		return
 	}
@@ -86,7 +86,7 @@ func HandleBookmarkArchiveFile(deps model.Dependencies, c model.WebContext) {
 		return
 	}
 
-	if !deps.Domains().Bookmarks().HasArchive(bookmark) {
+	if !deps.Domains().Archiver().HasArchive(bookmark) {
 		response.NotFound(c)
 		return
 	}

--- a/internal/http/handlers/bookmark_test.go
+++ b/internal/http/handlers/bookmark_test.go
@@ -2,10 +2,16 @@ package handlers
 
 import (
 	"context"
+	"image"
+	"image/jpeg"
 	"net/http"
+	"os"
 	"strconv"
+	"strings"
 	"testing"
 
+	"github.com/go-shiori/shiori/internal/core"
+	fp "path/filepath"
 	"github.com/go-shiori/shiori/internal/http/templates"
 	"github.com/go-shiori/shiori/internal/model"
 	"github.com/go-shiori/shiori/internal/testutil"
@@ -116,9 +122,52 @@ func TestBookmarkFileHandlers(t *testing.T) {
 	bookmarks, err := deps.Database().SaveBookmarks(context.TODO(), true, *bookmark)
 	require.NoError(t, err)
 
-	bookmark, err = deps.Domains().Archiver().DownloadBookmarkArchive(bookmarks[0])
+	// Use the new ArchiveBookmark method
+	archivalRequest := model.ArchivalRequest{
+		Bookmark:    &bookmarks[0],
+		ContentType: "text/html",
+		UserAgent:   "Shiori/1.0",
+		LogEnabled:  false,
+	}
+	err = deps.Domains().Archiver().ArchiveBookmark(archivalRequest)
 	require.NoError(t, err)
 
+	bookmarks[0].HasArchive = true
+	bookmarks, err = deps.Database().SaveBookmarks(context.TODO(), false, bookmarks[0])
+	require.NoError(t, err)
+	bookmark = &bookmarks[0]
+
+	// Create ebook
+	ebookPath := model.GetEbookPath(bookmark)
+	req := core.ProcessRequest{
+		DataDir:     deps.Config().Storage.DataDir,
+		Bookmark:    *bookmark,
+		Content:     strings.NewReader(bookmark.HTML),
+		ContentType: "text/html",
+	}
+	_, err = core.GenerateEbook(deps, req, ebookPath)
+	require.NoError(t, err)
+
+	bookmark.HasEbook = true
+	bookmarks, err = deps.Database().SaveBookmarks(context.TODO(), false, *bookmark)
+	require.NoError(t, err)
+	bookmark = &bookmarks[0]
+
+	// Create thumbnail
+	thumbPath := model.GetThumbnailPath(bookmark)
+	tmpFile, err := os.CreateTemp("", "thumb")
+	require.NoError(t, err)
+	defer os.Remove(tmpFile.Name())
+
+	// Create a simple thumbnail image
+	img := image.NewRGBA(image.Rect(0, 0, 100, 100))
+	err = jpeg.Encode(tmpFile, img, nil)
+	require.NoError(t, err)
+
+	err = deps.Domains().Storage().WriteFile(thumbPath, tmpFile)
+	require.NoError(t, err)
+
+	bookmark.ImageURL = fp.Join("/", "bookmark", strconv.Itoa(bookmark.ID), "thumb")
 	bookmarks, err = deps.Database().SaveBookmarks(context.TODO(), false, *bookmark)
 	require.NoError(t, err)
 	bookmark = &bookmarks[0]

--- a/internal/http/handlers/bookmark_test.go
+++ b/internal/http/handlers/bookmark_test.go
@@ -2,16 +2,12 @@ package handlers
 
 import (
 	"context"
-	"image"
-	"image/jpeg"
+	"fmt"
 	"net/http"
-	"os"
 	"strconv"
-	"strings"
 	"testing"
 
 	"github.com/go-shiori/shiori/internal/core"
-	fp "path/filepath"
 	"github.com/go-shiori/shiori/internal/http/templates"
 	"github.com/go-shiori/shiori/internal/model"
 	"github.com/go-shiori/shiori/internal/testutil"
@@ -107,6 +103,30 @@ func TestBookmarkContentHandler(t *testing.T) {
 	})
 }
 
+// downloadBookmarkArchive mimics the old DownloadBookmarkArchive behavior
+func downloadBookmarkArchive(deps model.Dependencies, book model.BookmarkDTO) (*model.BookmarkDTO, error) {
+	content, contentType, err := core.DownloadBookmark(book.URL)
+	if err != nil {
+		return nil, fmt.Errorf("error downloading url: %s", err)
+	}
+
+	processRequest := core.ProcessRequest{
+		DataDir:     deps.Config().Storage.DataDir,
+		Bookmark:    book,
+		Content:     content,
+		ContentType: contentType,
+	}
+
+	result, isFatalErr, err := core.ProcessBookmark(deps, processRequest)
+	content.Close()
+
+	if err != nil && isFatalErr {
+		return nil, fmt.Errorf("failed to process: %v", err)
+	}
+
+	return &result, nil
+}
+
 func TestBookmarkFileHandlers(t *testing.T) {
 	logger := logrus.New()
 	_, deps := testutil.GetTestConfigurationAndDependencies(t, context.Background(), logger)
@@ -122,52 +142,9 @@ func TestBookmarkFileHandlers(t *testing.T) {
 	bookmarks, err := deps.Database().SaveBookmarks(context.TODO(), true, *bookmark)
 	require.NoError(t, err)
 
-	// Use the new ArchiveBookmark method
-	archivalRequest := model.ArchivalRequest{
-		Bookmark:    &bookmarks[0],
-		ContentType: "text/html",
-		UserAgent:   "Shiori/1.0",
-		LogEnabled:  false,
-	}
-	err = deps.Domains().Archiver().ArchiveBookmark(archivalRequest)
+	bookmark, err = downloadBookmarkArchive(deps, bookmarks[0])
 	require.NoError(t, err)
 
-	bookmarks[0].HasArchive = true
-	bookmarks, err = deps.Database().SaveBookmarks(context.TODO(), false, bookmarks[0])
-	require.NoError(t, err)
-	bookmark = &bookmarks[0]
-
-	// Create ebook
-	ebookPath := model.GetEbookPath(bookmark)
-	req := core.ProcessRequest{
-		DataDir:     deps.Config().Storage.DataDir,
-		Bookmark:    *bookmark,
-		Content:     strings.NewReader(bookmark.HTML),
-		ContentType: "text/html",
-	}
-	_, err = core.GenerateEbook(deps, req, ebookPath)
-	require.NoError(t, err)
-
-	bookmark.HasEbook = true
-	bookmarks, err = deps.Database().SaveBookmarks(context.TODO(), false, *bookmark)
-	require.NoError(t, err)
-	bookmark = &bookmarks[0]
-
-	// Create thumbnail
-	thumbPath := model.GetThumbnailPath(bookmark)
-	tmpFile, err := os.CreateTemp("", "thumb")
-	require.NoError(t, err)
-	defer os.Remove(tmpFile.Name())
-
-	// Create a simple thumbnail image
-	img := image.NewRGBA(image.Rect(0, 0, 100, 100))
-	err = jpeg.Encode(tmpFile, img, nil)
-	require.NoError(t, err)
-
-	err = deps.Domains().Storage().WriteFile(thumbPath, tmpFile)
-	require.NoError(t, err)
-
-	bookmark.ImageURL = fp.Join("/", "bookmark", strconv.Itoa(bookmark.ID), "thumb")
 	bookmarks, err = deps.Database().SaveBookmarks(context.TODO(), false, *bookmark)
 	require.NoError(t, err)
 	bookmark = &bookmarks[0]

--- a/internal/model/archiver.go
+++ b/internal/model/archiver.go
@@ -1,0 +1,74 @@
+package model
+
+import (
+	"bytes"
+	"compress/gzip"
+	"fmt"
+	"io"
+)
+
+// Archive represents an interface for accessing archived web pages
+type Archive interface {
+	// Close closes the archive
+	Close()
+	// HasResource checks if a resource exists in the archive
+	HasResource(name string) bool
+	// Read reads a resource from the archive
+	Read(name string) ([]byte, string, error)
+}
+
+// SingleFileArchive is a simple implementation of Archive for external archivers
+// that wraps around string content instead of reading from files
+type SingleFileArchive struct {
+	content []byte
+	closed  bool
+}
+
+// NewSingleFileArchive creates a new SingleFileArchive instance
+func NewSingleFileArchive(content []byte) *SingleFileArchive {
+	return &SingleFileArchive{
+		content: content,
+		closed:  false,
+	}
+}
+
+// Close implements the Archive interface
+func (a *SingleFileArchive) Close() {
+	a.closed = true
+	a.content = nil
+}
+
+// HasResource implements the Archive interface
+func (a *SingleFileArchive) HasResource(name string) bool {
+	// For single file archives, we accept any resource name since we return the same content
+	return name != ""
+}
+
+// Read implements the Archive interface
+func (a *SingleFileArchive) Read(name string) ([]byte, string, error) {
+	if a.closed {
+		return nil, "", fmt.Errorf("archive is closed")
+	}
+	
+	if name == "" {
+		return nil, "", io.EOF
+	}
+
+	if len(a.content) == 0 {
+		return nil, "", fmt.Errorf("archive content is empty")
+	}
+
+	// Compress the content with gzip
+	var buf bytes.Buffer
+	gzipWriter := gzip.NewWriter(&buf)
+	if _, err := gzipWriter.Write(a.content); err != nil {
+		return nil, "", fmt.Errorf("failed to compress content: %v", err)
+	}
+	if err := gzipWriter.Close(); err != nil {
+		return nil, "", fmt.Errorf("failed to close gzip writer: %v", err)
+	}
+
+	return buf.Bytes(), "text/html", nil
+}
+
+

--- a/internal/model/archiver.go
+++ b/internal/model/archiver.go
@@ -40,8 +40,8 @@ func (a *SingleFileArchive) Close() {
 
 // HasResource implements the Archive interface
 func (a *SingleFileArchive) HasResource(name string) bool {
-	// For single file archives, we accept any resource name since we return the same content
-	return name != ""
+	// If any other file but the default one is requested, return false
+	return name == ""
 }
 
 // Read implements the Archive interface
@@ -50,7 +50,8 @@ func (a *SingleFileArchive) Read(name string) ([]byte, string, error) {
 		return nil, "", fmt.Errorf("archive is closed")
 	}
 	
-	if name == "" {
+	// If any other file but the default one is requested, return an error
+	if name != "" {
 		return nil, "", io.EOF
 	}
 

--- a/internal/model/bookmark.go
+++ b/internal/model/bookmark.go
@@ -85,3 +85,11 @@ func GetEbookPath(bookmark *BookmarkDTO) string {
 func GetArchivePath(bookmark *BookmarkDTO) string {
 	return filepath.Join("archive", strconv.Itoa(bookmark.ID))
 }
+
+// ArchivalRequest is the request for archiving a bookmark.
+type ArchivalRequest struct {
+    Bookmark    *BookmarkDTO
+    ContentType string // Optional: can be inferred if not provided
+    UserAgent   string // Optional: defaults to "Shiori/1.0"
+    LogEnabled  bool
+}

--- a/internal/model/bookmark.go
+++ b/internal/model/bookmark.go
@@ -86,10 +86,3 @@ func GetArchivePath(bookmark *BookmarkDTO) string {
 	return filepath.Join("archive", strconv.Itoa(bookmark.ID))
 }
 
-// ArchivalRequest is the request for archiving a bookmark.
-type ArchivalRequest struct {
-    Bookmark    *BookmarkDTO
-    ContentType string // Optional: can be inferred if not provided
-    UserAgent   string // Optional: defaults to "Shiori/1.0"
-    LogEnabled  bool
-}

--- a/internal/model/domains.go
+++ b/internal/model/domains.go
@@ -38,7 +38,7 @@ type AccountsDomain interface {
 }
 
 type ArchiverDomain interface {
-	DownloadBookmarkArchive(book BookmarkDTO) (*BookmarkDTO, error)
+	ArchiveBookmark(req ArchivalRequest) error
 	GetBookmarkArchive(book *BookmarkDTO) (*warc.Archive, error)
 }
 

--- a/internal/model/domains.go
+++ b/internal/model/domains.go
@@ -12,7 +12,6 @@ import (
 
 type BookmarksDomain interface {
 	HasEbook(b *BookmarkDTO) bool
-	HasArchive(b *BookmarkDTO) bool
 	HasThumbnail(b *BookmarkDTO) bool
 	GetBookmark(ctx context.Context, id DBID) (*BookmarkDTO, error)
 	GetBookmarks(ctx context.Context, ids []int) ([]BookmarkDTO, error)
@@ -40,6 +39,7 @@ type AccountsDomain interface {
 type ArchiverDomain interface {
 	ArchiveBookmark(book *BookmarkDTO, logEnabled bool) error
 	GetBookmarkArchive(book *BookmarkDTO) (*warc.Archive, error)
+	HasArchive(book *BookmarkDTO) bool
 }
 
 type StorageDomain interface {

--- a/internal/model/domains.go
+++ b/internal/model/domains.go
@@ -38,7 +38,7 @@ type AccountsDomain interface {
 }
 
 type ArchiverDomain interface {
-	ArchiveBookmark(req ArchivalRequest) error
+	ArchiveBookmark(book *BookmarkDTO, logEnabled bool) error
 	GetBookmarkArchive(book *BookmarkDTO) (*warc.Archive, error)
 }
 

--- a/internal/model/domains.go
+++ b/internal/model/domains.go
@@ -39,6 +39,7 @@ type ArchiverDomain interface {
 	ArchiveBookmark(book *BookmarkDTO, logEnabled bool) error
 	GetBookmarkArchive(book *BookmarkDTO) (Archive, error)
 	HasArchive(book *BookmarkDTO) bool
+	DeleteArchive(book *BookmarkDTO) error
 }
 
 type StorageDomain interface {

--- a/internal/model/domains.go
+++ b/internal/model/domains.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"time"
 
-	"github.com/go-shiori/warc"
 	"github.com/spf13/afero"
 )
 
@@ -38,7 +37,7 @@ type AccountsDomain interface {
 
 type ArchiverDomain interface {
 	ArchiveBookmark(book *BookmarkDTO, logEnabled bool) error
-	GetBookmarkArchive(book *BookmarkDTO) (*warc.Archive, error)
+	GetBookmarkArchive(book *BookmarkDTO) (Archive, error)
 	HasArchive(book *BookmarkDTO) bool
 }
 

--- a/internal/model/main.go
+++ b/internal/model/main.go
@@ -10,4 +10,10 @@ var (
 const (
 	// ShioriNamespace
 	ShioriURLNamespace = "https://github.com/go-shiori/shiori"
+
+)
+
+var (
+	// UserAgent: default user agent used for downloads and archival
+	UserAgent = "Shiori/" + BuildVersion + " (" + BuildCommit + ") (+https://github.com/go-shiori/shiori)"
 )

--- a/internal/testutil/shiori.go
+++ b/internal/testutil/shiori.go
@@ -39,7 +39,7 @@ func GetTestConfigurationAndDependencies(t *testing.T, ctx context.Context, logg
 
 	deps := dependencies.NewDependencies(logger, db, cfg)
 	deps.Domains().SetAccounts(domains.NewAccountsDomain(deps))
-	deps.Domains().SetArchiver(domains.NewArchiverDomain(deps))
+	deps.Domains().SetArchiver(domains.NewBuiltInArchiver(deps))
 	deps.Domains().SetAuth(domains.NewAuthDomain(deps))
 	deps.Domains().SetBookmarks(domains.NewBookmarksDomain(deps))
 	deps.Domains().SetStorage(domains.NewStorageDomain(deps, afero.NewBasePathFs(afero.NewOsFs(), cfg.Storage.DataDir)))

--- a/internal/webserver/handler-api-ext.go
+++ b/internal/webserver/handler-api-ext.go
@@ -139,13 +139,14 @@ func (h *Handler) ApiDeleteViaExtension(w http.ResponseWriter, r *http.Request, 
 		err = h.DB.DeleteBookmarks(ctx, book.ID)
 		checkError(err)
 
-		// Delete thumbnail image and archives from local disk
+		// Delete thumbnail image and archives using proper interfaces
 		strID := strconv.Itoa(book.ID)
 		imgPath := fp.Join(h.DataDir, "thumb", strID)
-		archivePath := fp.Join(h.DataDir, "archive", strID)
-
+		
 		os.Remove(imgPath)
-		os.Remove(archivePath)
+		
+		// Use ArchiverDomain to delete archive (works for both built-in and external)
+		h.dependencies.Domains().Archiver().DeleteArchive(&book)
 	}
 
 	fmt.Fprint(w, 1)

--- a/internal/webserver/handler-api.go
+++ b/internal/webserver/handler-api.go
@@ -95,14 +95,13 @@ func (h *Handler) ApiGetBookmarks(w http.ResponseWriter, r *http.Request, ps htt
 	for i := range bookmarks {
 		strID := strconv.Itoa(bookmarks[i].ID)
 		imgPath := fp.Join(h.DataDir, "thumb", strID)
-		archivePath := fp.Join(h.DataDir, "archive", strID)
 		ebookPath := fp.Join(h.DataDir, "ebook", strID+".epub")
 
 		if FileExists(imgPath) {
 			bookmarks[i].ImageURL = path.Join(h.RootPath, "bookmark", strID, "thumb")
 		}
 
-		if FileExists(archivePath) {
+		if h.dependencies.Domains().Archiver().HasArchive(&bookmarks[i]) {
 			bookmarks[i].HasArchive = true
 		}
 		if FileExists(ebookPath) {

--- a/internal/webserver/handler-api.go
+++ b/internal/webserver/handler-api.go
@@ -274,16 +274,18 @@ func (h *Handler) ApiDeleteBookmark(w http.ResponseWriter, r *http.Request, ps h
 	err = h.DB.DeleteBookmarks(ctx, ids...)
 	checkError(err)
 
-	// Delete thumbnail image and archives from local disk
+	// Delete thumbnail image and archives using proper interfaces
 	for _, id := range ids {
 		strID := strconv.Itoa(id)
 		imgPath := fp.Join(h.DataDir, "thumb", strID)
-		archivePath := fp.Join(h.DataDir, "archive", strID)
 		ebookPath := fp.Join(h.DataDir, "ebook", strID+".epub")
 
 		os.Remove(imgPath)
-		os.Remove(archivePath)
 		os.Remove(ebookPath)
+		
+		// Use ArchiverDomain to delete archive (works for both built-in and external)
+		bookmark := &model.BookmarkDTO{ID: id}
+		h.dependencies.Domains().Archiver().DeleteArchive(bookmark)
 	}
 
 	fmt.Fprint(w, 1)


### PR DESCRIPTION
Hello Shiori team! :wave: 

First of all, thank you for this project, I absolutely love the idea and how lightweight it is.

However, in the modern world, some things can't be ~nice~ done purely in Go and stay lightweight.

One example is archiving some heavy pages where content is rendered by JS fetching data from some API (e.g. the very Github :see_no_evil:). Thus, it seems, there's no way to avoid using some kind of web engine, rendering the page, running the JS and then capturing properly rendered DOM.

Another one would be archiving something like YT videos, where you'd need to run the whole yt-dlp stack to get the actual content.

At the same time, the approach of using such 3rd party suites has a set of drawbacks:
1. Size and complexity: if bundled with Shiori, they'd extremely blow up the project and essentially defy its purpose and the main advantage.
2. Security: in case of using a web engine for archival, we literally run some unknown 3rd party JS code in it; even given strong sandboxing mechanisms of modern web engines, it still might be a sound idea to isolate it even further by running such processing inside more isolated environments like separate VMs or even physical machines.
3. Performance: running such kind of processing on low-power hardware (like Raspberry Pi or Intel Atom) creates substantial challenges for such hardware; in this case it also might be sound to offload such processing to more power hardware and process it opportunistically in batches while keeping Shiori itself always up and running on low-power and low-consumption hardware.
4. Storage: similar to the issue above, archiving heavy content requires a lot of storage which might not be feasible to connect to the hardware where Shiori is running.

---

Of course, one could live without such archival (or use another project altogether), but it became interesting to me to check what would take to implement an elegant-ish solution to make it possible to keep Shiori small, easy and lightweight yet make it optionally extensible with external plugins to enable integrations with external archivers.

Something like this:
<img width="4861" height="1831" alt="image" src="https://github.com/user-attachments/assets/0366e5ff-e28e-4c50-9f0e-65e7a3fdd8ef" />

The idea is to, alongside with the internal already existing archiver, have an external one — either completely replacing the built-in one if the user opts in, or working in parallel with it (thus, enabling both local and external archival). They both would implement a very simple internal interface, and the external archiver would just be exposing that interface over some kind of a transport (probably regular REST API would be the go to approach, but there are options here).

Then the external archiver / multiplexer service (a completely separate thing, not coupled to Shiori in any way) would be running on a separate machine (or on the same machine — wherever the user chooses to deploy it) and routing the archival requests to the backends it supports (and the user decided to configure).

---

This PR very simple proof-of-concept with the external archiver that doesn't implement any specific transport yet, but just calls an external binary (it was just the easiest way to implement and test it — I still think it makes more sense to use some kind of a network transport for that instead).

_Please keep in mind that this is a PoC and I don't have intentions to merge it as is (hence, publishing it as a draft)._

However, if you like the idea and would provide some feedback on it, I'd be glad to continue working in this direction and eventually come up with a PR that would implement the external archiver part (the one inside the Shiori box) fitting the project structure, aligned with the roadmap, nicely coded, properly documented and covered with tests :crossed_fingers: :smiley: 

Hope it all makes sense. I'll also try to explain some code decisions in the inline comments in the PR itself.

Cheers!