### PR TITLE
Fix dialogs not closing properly

### DIFF
--- a/internal/view/assets/js/component/dialog.js
+++ b/internal/view/assets/js/component/dialog.js
@@ -89,22 +89,23 @@ export default {
 		mainClick: {
 			type: Function,
 			default() {
-				this.visible = false;
+				this.$emit("dialog-close");
 			},
 		},
 		secondClick: {
 			type: Function,
 			default() {
-				this.visible = false;
+				this.$emit("dialog-close");
 			},
 		},
 		escPressed: {
 			type: Function,
 			default() {
-				this.visible = false;
+				this.$emit("dialog-close");
 			},
 		},
 	},
+	emits: ["dialog-close"],
 	data() {
 		return {
 			formFields: [],

--- a/internal/view/assets/js/page/home.js
+++ b/internal/view/assets/js/page/home.js
@@ -77,14 +77,14 @@ var template = `
         </pagination-box>
     </div>
     <div class="loading-overlay" v-if="loading"><i class="fas fa-fw fa-spin fa-spinner"></i></div>
-    <custom-dialog id="dialog-tags" v-bind="dialogTags">
+    <custom-dialog id="dialog-tags" v-bind="dialogTags" @dialog-close="dialogTags.visible = false">
         <a @click="filterTag('*')">(all tagged)</a>
         <a @click="filterTag('*', true)">(all untagged)</a>
         <a v-for="tag in tags" @click="dialogTagClicked($event, tag)">
             #{{tag.name}}<span>{{tag.bookmark_count}}</span>
         </a>
     </custom-dialog>
-    <custom-dialog v-bind="dialog"/>
+    <custom-dialog v-bind="dialog" @dialog-close="dialog.visible = false"/>
 </div>`;
 
 import paginationBox from "../component/pagination.js";

--- a/internal/view/assets/js/page/setting.js
+++ b/internal/view/assets/js/page/setting.js
@@ -88,14 +88,14 @@ var template = `
 		<details v-if="activeAccount.owner" class="setting-group" id="setting-system-info">
 			<summary>System info</summary>
 			<ul>
-				<li><b>Shiori version:</b> <span>{{system.version?.tag}}<span></li>
+				<li><b>Shiori version:</b> <span>{{system.version?.tag}}</span></li>
 				<li><b>Database engine:</b> <span>{{system.database}}</span></li>
 				<li><b>Operating system:</b> <span>{{system.os}}</span></li>
 			</ul>
 		</details>
     </div>
     <div class="loading-overlay" v-if="loading"><i class="fas fa-fw fa-spin fa-spinner"></i></div>
-    <custom-dialog v-bind="dialog"/>
+    <custom-dialog v-bind="dialog" @dialog-close="dialog.visible = false"/>
 </div>`;
 
 import customDialog from "../component/dialog.js";

--- a/internal/view/index.html
+++ b/internal/view/index.html
@@ -37,7 +37,7 @@
     		<keep-alive>
     			<component :is="activePage" :active-account="activeAccount" :app-options="appOptions" @setting-changed="saveSetting"></component>
     		</keep-alive>
-    		<custom-dialog v-bind="dialog"></custom-dialog>
+    		<custom-dialog v-bind="dialog" @dialog-close="dialog.visible = false"></custom-dialog>
 		</div>
 	</div>
 


### PR DESCRIPTION
After pressing 'Cancel' it would seem dialogs become visible every time the view gets re-rendered. The Vue development version warns about this in the console as follows:
```
[Vue warn]: Avoid mutating a prop directly since the value will be overwritten
whenever the parent component re-renders. Instead, use a data or computed property
based on the prop's value. Prop being mutated: "visible"
``` 
This PR fixes the issue by emitting the `dialog-close` event instead of writing to the `visible` prop.