### PR TITLE
fix: persist tag removal on bookmark update and refresh tag counts

### DIFF
--- a/internal/database/database_test.go
+++ b/internal/database/database_test.go
@@ -21,6 +21,7 @@ func testDatabase(t *testing.T, dbFactory testDatabaseFactory) {
 		"testCreateBookmarkWithContent":         testCreateBookmarkWithContent,
 		"testCreateBookmarkTwice":               testCreateBookmarkTwice,
 		"testCreateBookmarkWithTag":             testCreateBookmarkWithTag,
+		"testUpdateBookmarkRemoveTag":           testUpdateBookmarkRemoveTag,
 		"testCreateTwoDifferentBookmarks":       testCreateTwoDifferentBookmarks,
 		"testUpdateBookmark":                    testUpdateBookmark,
 		"testUpdateBookmarkUpdatesModifiedTime": testUpdateBookmarkUpdatesModifiedTime,
@@ -154,6 +155,42 @@ func testCreateBookmarkWithTag(t *testing.T, db model.DB) {
 	assert.NoError(t, err, "Save bookmarks must not fail")
 	assert.Equal(t, book.URL, result[0].URL)
 	assert.Equal(t, book.Tags[0].Name, result[0].Tags[0].Name)
+}
+
+// testUpdateBookmarkRemoveTag verifies that re-saving a bookmark with one of its
+// tags marked Deleted actually removes the bookmark-tag association.
+func testUpdateBookmarkRemoveTag(t *testing.T, db model.DB) {
+	ctx := context.TODO()
+
+	book := model.BookmarkDTO{
+		URL:   "https://github.com/go-shiori/shiori",
+		Title: "shiori",
+		Tags: []model.TagDTO{
+			{Tag: model.Tag{Name: "keep"}},
+			{Tag: model.Tag{Name: "remove"}},
+		},
+	}
+
+	result, err := db.SaveBookmarks(ctx, true, book)
+	require.NoError(t, err, "Save bookmarks must not fail")
+	require.Len(t, result, 1)
+	require.Len(t, result[0].Tags, 2, "Bookmark should have 2 tags after initial save")
+
+	saved := result[0]
+	for i := range saved.Tags {
+		if saved.Tags[i].Name == "remove" {
+			saved.Tags[i].Deleted = true
+		}
+	}
+
+	_, err = db.SaveBookmarks(ctx, false, saved)
+	require.NoError(t, err, "Save bookmarks must not fail")
+
+	bookmarks, err := db.GetBookmarks(ctx, model.DBGetBookmarksOptions{IDs: []int{saved.ID}})
+	require.NoError(t, err)
+	require.Len(t, bookmarks, 1)
+	require.Len(t, bookmarks[0].Tags, 1, "Removed tag should be gone after save")
+	assert.Equal(t, "keep", bookmarks[0].Tags[0].Name)
 }
 
 func testCreateBookmarkTwice(t *testing.T, db model.DB) {

--- a/internal/database/mysql.go
+++ b/internal/database/mysql.go
@@ -229,9 +229,11 @@ func (db *MySQLDatabase) SaveBookmarks(ctx context.Context, create bool, bookmar
 			newTags := []model.TagDTO{}
 			for _, tag := range book.Tags {
 				t := tag.ToDTO()
-				// If it's deleted tag, delete and continue
-				if t.Deleted {
-					_, err = stmtDeleteBookTag.ExecContext(ctx, book.ID, t.ID)
+				// If it's deleted tag, delete and continue.
+				// Read Deleted from `tag` (TagDTO) — `t` was rebuilt via the
+				// embedded *Tag.ToDTO() and does not carry the flag.
+				if tag.Deleted {
+					_, err = stmtDeleteBookTag.ExecContext(ctx, book.ID, tag.ID)
 					if err != nil {
 						return errors.WithStack(err)
 					}

--- a/internal/database/pg.go
+++ b/internal/database/pg.go
@@ -224,9 +224,11 @@ func (db *PGDatabase) SaveBookmarks(ctx context.Context, create bool, bookmarks 
 			newTags := []model.TagDTO{}
 			for _, tag := range book.Tags {
 				t := tag.ToDTO()
-				// If it's deleted tag, delete and continue
-				if t.Deleted {
-					_, err = stmtDeleteBookTag.ExecContext(ctx, book.ID, t.ID)
+				// If it's deleted tag, delete and continue.
+				// Read Deleted from `tag` (TagDTO) — `t` was rebuilt via the
+				// embedded *Tag.ToDTO() and does not carry the flag.
+				if tag.Deleted {
+					_, err = stmtDeleteBookTag.ExecContext(ctx, book.ID, tag.ID)
 					if err != nil {
 						return errors.WithStack(err)
 					}

--- a/internal/database/sqlite.go
+++ b/internal/database/sqlite.go
@@ -329,8 +329,10 @@ func (db *SQLiteDatabase) SaveBookmarks(ctx context.Context, create bool, bookma
 			newTags := []model.TagDTO{}
 			for _, tag := range book.Tags {
 				t := tag.ToDTO()
-				// If it's deleted tag, delete and continue
-				if t.Deleted {
+				// If it's deleted tag, delete and continue.
+				// Read Deleted from `tag` (TagDTO) — `t` was rebuilt via the
+				// embedded *Tag.ToDTO() and does not carry the flag.
+				if tag.Deleted {
 					_, err = stmtDeleteBookTag.ExecContext(ctx, book.ID, tag.ID)
 					if err != nil {
 						return fmt.Errorf("failed to execute delete bookmark statement: %w", err)

--- a/internal/view/assets/js/page/home.js
+++ b/internal/view/assets/js/page/home.js
@@ -168,6 +168,16 @@ export default {
 			this.search = "";
 			this.loadData(true, true);
 		},
+		async refreshTags() {
+			try {
+				const tagsUrl = new URL("api/tags", document.baseURI);
+				this.tags = await apiRequest(tagsUrl);
+			} catch (err) {
+				// Don't interrupt the user with an error dialog — the primary
+				// action already succeeded; only the tag counts are stale.
+				console.error("Failed to refresh tags:", err);
+			}
+		},
 		async loadData(saveState, fetchTags) {
 			if (this.loading) return;
 
@@ -443,6 +453,7 @@ export default {
 						this.dialog.loading = false;
 						this.dialog.visible = false;
 						this.bookmarks.splice(0, 0, json);
+						this.refreshTags();
 					} catch (err) {
 						this.dialog.loading = false;
 						this.showErrorDialog(err.message);
@@ -535,6 +546,7 @@ export default {
 						this.dialog.loading = false;
 						this.dialog.visible = false;
 						this.bookmarks.splice(index, 1, json);
+						this.refreshTags();
 					} catch (err) {
 						this.dialog.loading = false;
 						this.showErrorDialog(err.message);
@@ -589,6 +601,7 @@ export default {
 						this.dialog.loading = false;
 						this.dialog.visible = false;
 						indices.forEach((index) => this.bookmarks.splice(index, 1));
+						this.refreshTags();
 
 						if (this.bookmarks.length < 20) {
 							this.loadData(false);
@@ -842,6 +855,7 @@ export default {
 							var item = items.find((el) => el.id === book.id);
 							this.bookmarks.splice(item.index, 1, book);
 						});
+						this.refreshTags();
 					} catch (err) {
 						this.selection = [];
 						this.editMode = false;


### PR DESCRIPTION
## Problem

Editing a bookmark and removing a tag from the comma-separated list did not actually remove the bookmark↔tag association. Additionally, the Existing Tags dialog kept showing stale bookmark counts after edits.

## Cause

In `SaveBookmarks` (sqlite, postgres, mysql), the per-tag loop did:

```go
for _, tag := range book.Tags { // tag is a TagDTO with Deleted=true
    t := tag.ToDTO()             // rebuilt via embedded *Tag.ToDTO()
    if t.Deleted { ... delete ... }
```

`ToDTO()` is defined on `*Tag` and returns a fresh `TagDTO` carrying only `ID` and `Name`, so `t.Deleted` was always `false` and the delete branch was unreachable. Tags marked for removal by `ApiUpdateBookmark` were then re-inserted by the same loop.

Introduced in #1064 when the embedded-struct shape changed.

## Fix

- Read `tag.Deleted` from the original `TagDTO` instead of the rebuilt `t`. Applied to all three database drivers.
- Add a database-level regression test (`testUpdateBookmarkRemoveTag`) that saves a bookmark with two tags, marks one as deleted, re-saves, and asserts only the surviving tag is present after re-fetch.
- In the legacy webapp (`home.js`), add a `refreshTags()` helper and call it after edit, bulk add tags, create, and delete — so the Existing Tags dialog reflects the new counts without a manual page refresh.

## Test plan

- [x] `go test -tags test_sqlite_only ./internal/database/...` passes with the fix
- [x] Confirmed the new test fails without the fix (`should have 1 item(s), but has 2`)
- [x] Manually verified in the webapp: removing a tag from a bookmark now persists, and the dialog counts update without reload