### PR TITLE
feat: add delete tag action to existing tags dialog

### DIFF
--- a/internal/view/assets/js/component/dialog.js
+++ b/internal/view/assets/js/component/dialog.js
@@ -44,6 +44,12 @@ var template = `
 		<div class="custom-dialog-footer">
 			<i v-if="loading" class="fas fa-fw fa-spinner fa-spin"></i>
 			<slot v-else name="custom-footer">
+				<a v-if="thirdText"
+					:tabindex="btnTabIndex+2"
+					@click="handleThirdClick"
+					@keyup.enter="handleThirdClick"
+					class="custom-dialog-button">{{thirdText}}
+				</a>
 				<a v-if="secondText"
 					:tabindex="btnTabIndex+1"
 					@click="handleSecondClick"
@@ -86,6 +92,7 @@ export default {
 			default: "OK",
 		},
 		secondText: String,
+		thirdText: String,
 		mainClick: {
 			type: Function,
 			default() {
@@ -93,6 +100,12 @@ export default {
 			},
 		},
 		secondClick: {
+			type: Function,
+			default() {
+				this.visible = false;
+			},
+		},
+		thirdClick: {
 			type: Function,
 			default() {
 				this.visible = false;
@@ -175,6 +188,9 @@ export default {
 		},
 		handleSecondClick() {
 			this.secondClick();
+		},
+		handleThirdClick() {
+			this.thirdClick();
 		},
 		handleEscPressed() {
 			this.escPressed();

--- a/internal/view/assets/js/page/home.js
+++ b/internal/view/assets/js/page/home.js
@@ -118,23 +118,27 @@ export default {
 
 			dialogTags: {
 				visible: false,
-				editMode: false,
+				mode: "view",
 				title: "Existing Tags",
 				mainText: "OK",
 				secondText: "Rename Tags",
+				thirdText: "Delete Tags",
 				mainClick: () => {
-					if (this.dialogTags.editMode) {
-						this.dialogTags.editMode = false;
+					if (this.dialogTags.mode !== "view") {
+						this.dialogTags.mode = "view";
 					} else {
 						this.dialogTags.visible = false;
 					}
 				},
 				secondClick: () => {
-					this.dialogTags.editMode = true;
+					this.dialogTags.mode = "rename";
+				},
+				thirdClick: () => {
+					this.dialogTags.mode = "delete";
 				},
 				escPressed: () => {
 					this.dialogTags.visible = false;
-					this.dialogTags.editMode = false;
+					this.dialogTags.mode = "view";
 				},
 			},
 		};
@@ -145,15 +149,22 @@ export default {
 		},
 	},
 	watch: {
-		"dialogTags.editMode"(editMode) {
-			if (editMode) {
+		"dialogTags.mode"(mode) {
+			if (mode === "rename") {
 				this.dialogTags.title = "Rename Tags";
 				this.dialogTags.mainText = "Cancel";
 				this.dialogTags.secondText = "";
+				this.dialogTags.thirdText = "";
+			} else if (mode === "delete") {
+				this.dialogTags.title = "Delete Tags";
+				this.dialogTags.mainText = "Cancel";
+				this.dialogTags.secondText = "";
+				this.dialogTags.thirdText = "";
 			} else {
 				this.dialogTags.title = "Existing Tags";
 				this.dialogTags.mainText = "OK";
 				this.dialogTags.secondText = "Rename Tags";
+				this.dialogTags.thirdText = "Delete Tags";
 			}
 		},
 	},
@@ -285,11 +296,14 @@ export default {
 			return this.selection.findIndex((el) => el.id === bookId) > -1;
 		},
 		dialogTagClicked(event, tag) {
-			if (!this.dialogTags.editMode) {
-				this.filterTag(tag.name, event.altKey);
-			} else {
+			if (this.dialogTags.mode === "rename") {
 				this.dialogTags.visible = false;
 				this.showDialogRenameTag(tag);
+			} else if (this.dialogTags.mode === "delete") {
+				this.dialogTags.visible = false;
+				this.showDialogDeleteTag(tag);
+			} else {
+				this.filterTag(tag.name, event.altKey);
 			}
 		},
 		bookmarkTagClicked(event, tagName) {
@@ -299,7 +313,7 @@ export default {
 			// Set default parameter
 			excludeMode = typeof excludeMode === "boolean" ? excludeMode : false;
 
-			if (this.dialogTags.editMode) {
+			if (this.dialogTags.mode !== "view") {
 				return;
 			}
 
@@ -853,10 +867,14 @@ export default {
 		},
 		showDialogTags() {
 			this.dialogTags.visible = true;
-			this.dialogTags.editMode = false;
-			this.dialogTags.secondText = this.activeAccount.owner
-				? "Rename Tags"
-				: "";
+			this.dialogTags.mode = "view";
+			if (this.activeAccount.owner) {
+				this.dialogTags.secondText = "Rename Tags";
+				this.dialogTags.thirdText = "Delete Tags";
+			} else {
+				this.dialogTags.secondText = "";
+				this.dialogTags.thirdText = "";
+			}
 		},
 		showDialogRenameTag(tag) {
 			this.showDialog({
@@ -904,7 +922,7 @@ export default {
 						this.dialog.loading = false;
 						this.dialog.visible = false;
 						this.dialogTags.visible = true;
-						this.dialogTags.editMode = false;
+						this.dialogTags.mode = "view";
 						this.tags.sort((a, b) => {
 							var aName = a.name.toLowerCase(),
 								bName = b.name.toLowerCase();
@@ -921,7 +939,66 @@ export default {
 					} catch (err) {
 						this.dialog.loading = false;
 						this.dialogTags.visible = false;
-						this.dialogTags.editMode = false;
+						this.dialogTags.mode = "view";
+						this.showErrorDialog(err.message);
+					}
+				},
+			});
+		},
+		showDialogDeleteTag(tag) {
+			var bookmarkLabel =
+				tag.bookmark_count === 1 ? "1 bookmark" : `${tag.bookmark_count} bookmarks`;
+			this.showDialog({
+				title: "Delete Tag",
+				content: `Delete tag "#${tag.name}"? It will be removed from ${bookmarkLabel}. This action is irreversible.`,
+				mainText: "Delete",
+				secondText: "Cancel",
+				secondClick: () => {
+					this.dialog.visible = false;
+					this.dialogTags.visible = true;
+				},
+				escPressed: () => {
+					this.dialog.visible = false;
+					this.dialogTags.visible = true;
+				},
+				mainClick: async () => {
+					var rxSpace = /\s+/g,
+						tagQuery = rxSpace.test(tag.name)
+							? `"#${tag.name}"`
+							: `#${tag.name}`;
+
+					this.dialog.loading = true;
+					try {
+						await apiRequest(
+							new URL("api/v1/tags/" + tag.id, document.baseURI),
+							{ method: "DELETE" },
+						);
+
+						this.dialog.loading = false;
+						this.dialog.visible = false;
+						this.dialogTags.visible = true;
+						this.dialogTags.mode = "view";
+
+						// Drop the tag from the local list. If the current
+						// search filters on it, clear that fragment and reload.
+						this.tags = this.tags.filter((t) => t.id !== tag.id);
+						if (this.search.includes(tagQuery)) {
+							this.search = this.search
+								.replace("-tag:" + tagQuery, "")
+								.replace("tag:" + tagQuery, "")
+								.replace(tagQuery, "")
+								.trim()
+								.replace(/\s+/g, " ");
+							this.loadData();
+						} else {
+							// Bookmarks visible on this page may have been tagged;
+							// refresh so their tag chips no longer show this one.
+							this.loadData(false);
+						}
+					} catch (err) {
+						this.dialog.loading = false;
+						this.dialogTags.visible = false;
+						this.dialogTags.mode = "view";
 						this.showErrorDialog(err.message);
 					}
 				},


### PR DESCRIPTION
## Summary

The existing tags dialog currently lets owners enter a rename mode. This adds a parallel **delete mode**: pick a tag, confirm, and the tag is removed from the database along with every bookmark association.

The backend already supports this — `DELETE /api/v1/tags/{id}` transactionally drops `bookmark_tag` rows for the tag and then deletes the tag itself (see `(*SQLiteDatabase).DeleteTag` and the pg/mysql equivalents). No backend changes were needed.

## UI

Existing Tags dialog (owner) now has three footer actions:

```
... DELETE TAGS    RENAME TAGS    OK
```

- **OK** — closes the dialog (unchanged)
- **RENAME TAGS** — enters rename mode; clicking a tag opens the existing rename dialog (unchanged)
- **DELETE TAGS** *(new)* — enters delete mode; clicking a tag opens a confirmation that reports how many bookmarks will be affected

`dialogTags.editMode` (boolean) is refactored into `dialogTags.mode` (`view` / `rename` / `delete`).

## On success

- Tag is removed from the local `this.tags` list
- Any `#tag` / `tag:tag` / `-tag:tag` fragment in the search box that references the deleted tag is stripped
- The bookmark list is reloaded so chips on currently-displayed entries are refreshed

## Component change

`custom-dialog` gains optional `thirdText` / `thirdClick` props. The new button renders only when `thirdText` is set, so every existing caller is unaffected.

## Test plan

- [x] `go build ./...`
- [x] `go test -tags test_sqlite_only ./internal/database/... ./internal/http/handlers/api/v1/...` — passes
- [x] Manual: create a bookmark with tag `test`, open Existing Tags → Delete Tags → click `#test` → confirm → tag disappears from the dialog and from the bookmark chip, count for other tags unchanged
- [x] Manual: non-owner accounts still see only the OK button (the Rename Tags / Delete Tags buttons are gated on `activeAccount.owner`)