### PR TITLE
fix: show version on login page again (#1183)

### DIFF
--- a/internal/view/assets/js/component/login.js
+++ b/internal/view/assets/js/component/login.js
@@ -28,12 +28,21 @@ const template = `
             </div>
         </form>
     </div>
+    <footer class="login-footer" v-if="version !== ''">
+        <p>{{version}}</p>
+    </footer>
 </div>
 `;
 
 export default {
 	name: "login-view",
 	template,
+	props: {
+		version: {
+			type: String,
+			default: "",
+		},
+	},
 	data() {
 		return {
 			error: "",

--- a/internal/view/index.html
+++ b/internal/view/index.html
@@ -23,7 +23,7 @@
 
 <body>
 	<div id="app">
-		<login-view v-if="isLoggedIn === false && loginRequired" @login-success="onLoginSuccess"></login-view>
+		<login-view v-if="isLoggedIn === false && loginRequired" :version="version" @login-success="onLoginSuccess"></login-view>
 		<div id="main-scene" v-else-if="isLoggedIn === true">
     		<div id="main-sidebar">
     			<a v-for="item in sidebarItems" :title="item.title" :class="{active: activePage === item.page}" @click="switchPage(item.page)">
@@ -62,6 +62,7 @@
 			data: {
 				isLoggedIn: null,
 				loginRequired: false,
+				version: "$$.Version$$",
 				activePage: "page-home",
 				sidebarItems: [{
 					title: "Home",


### PR DESCRIPTION
The version footer was lost when login.html was refactored into a component in #1017. Since login.js is served as a static asset and not processed by the template engine, pass the injected version from index.html down to the login component as a prop.