### PR TITLE
fix: accept postgresql:// scheme in database URL

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -91,6 +91,8 @@ You can find additional details in [go mysql sql driver documentation](https://g
 
 PostgreSQL example: `SHIORI_DATABASE_URL="postgres://pqgotest:password@hostname/database?sslmode=verify-full"`
 
+Both the `postgres://` and `postgresql://` URL schemes are accepted.
+
 You can find additional details in [go postgres sql driver documentation](https://pkg.go.dev/github.com/lib/pq).
 
 ## Reverse proxies and the webroot path

--- a/internal/database/connect_test.go
+++ b/internal/database/connect_test.go
@@ -1,0 +1,54 @@
+package database
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestConnectDatabaseScheme verifies that Connect recognizes the database URL
+// schemes it is supposed to support. In particular, the PostgreSQL driver
+// (lib/pq) accepts both the "postgres://" and "postgresql://" URL prefixes, so
+// Connect must route both to the PostgreSQL implementation instead of rejecting
+// "postgresql://" as an unsupported scheme.
+//
+// See https://github.com/go-shiori/shiori/issues/1098
+func TestConnectDatabaseScheme(t *testing.T) {
+	// Point the connection at a loopback address with no listener so the
+	// connection attempt fails fast and deterministically. We only care about
+	// the scheme routing here, not about establishing a real connection.
+	const unreachable = "127.0.0.1:1"
+
+	t.Run("postgresql scheme is recognized", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+
+		_, err := Connect(ctx, "postgresql://shiori:shiori@"+unreachable+"/shiori?sslmode=disable")
+		require.Error(t, err)
+		assert.NotContains(t, err.Error(), "unsupported database scheme",
+			"postgresql:// should be routed to the PostgreSQL driver, not rejected as an unsupported scheme")
+	})
+
+	t.Run("postgres scheme is recognized", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+
+		_, err := Connect(ctx, "postgres://shiori:shiori@"+unreachable+"/shiori?sslmode=disable")
+		require.Error(t, err)
+		assert.NotContains(t, err.Error(), "unsupported database scheme",
+			"postgres:// should be routed to the PostgreSQL driver")
+	})
+
+	t.Run("unknown scheme is rejected", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+
+		_, err := Connect(ctx, "mongodb://shiori:shiori@"+unreachable+"/shiori")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "unsupported database scheme",
+			"unknown schemes must still be rejected")
+	})
+}

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -31,7 +31,7 @@ func Connect(ctx context.Context, dbURL string) (model.DB, error) {
 	case "mysql":
 		urlNoSchema := strings.Split(dbURL, "://")[1]
 		return OpenMySQLDatabase(ctx, urlNoSchema)
-	case "postgres":
+	case "postgres", "postgresql":
 		return OpenPGDatabase(ctx, dbURL)
 	case "sqlite":
 		return OpenSQLiteDatabase(ctx, dbU.Path[1:])


### PR DESCRIPTION
## What

`database.Connect` only matched the `postgres` URL scheme, so a `SHIORI_DATABASE_URL` like `postgresql://user:pass@host:5432/db` failed at startup with `unsupported database scheme: postgresql`.

Many tools emit connection URIs using the `postgresql://` prefix — e.g. cloudnative-pg secrets expose `uri: postgresql://...` — forcing users to hand-edit the scheme to `postgres://` (issue #1098).

## Why this is safe

The PostgreSQL driver in use (lib/pq) already accepts both the `postgres://` and `postgresql://` prefixes in its connector (`NewConnector`), so routing both schemes to `OpenPGDatabase` and passing the URL through unchanged is sufficient — no connection-string rewriting needed.

## Changes

- `internal/database/database.go`: route both `postgres` and `postgresql` schemes to the PostgreSQL implementation.
- `internal/database/connect_test.go`: add `TestConnectDatabaseScheme` covering both accepted schemes and rejection of unknown schemes (fails before, passes after; green under `-race`).
- `docs/Configuration.md`: note that both schemes are accepted.

Fixes #1098

## Disclosure

This change was prepared with the assistance of an AI agent (Claude). The author has reviewed the diff, verified the driver behavior, and confirmed the test fails before and passes after the change.
