### PR TITLE
Fix bookmark tag editing to keep/remove tags correctly

### DIFF
--- a/internal/webserver/handler-api.go
+++ b/internal/webserver/handler-api.go
@@ -333,14 +333,21 @@ func (h *Handler) ApiUpdateBookmark(w http.ResponseWriter, r *http.Request, ps h
 		panic(fmt.Errorf("failed to clean URL: %v", err))
 	}
 
-	// Set new tags
+	// Set new tags. SaveBookmarks normalizes tag names to lowercase with
+	// collapsed whitespace before comparing, so match on the normalized form
+	// here; otherwise a tag edited with different casing/spaces would be left
+	// marked for deletion and re-added as a duplicate instead of being kept.
+	normalize := func(s string) string {
+		return strings.Join(strings.Fields(strings.ToLower(s)), " ")
+	}
 	for i := range book.Tags {
 		book.Tags[i].Deleted = true
 	}
 
 	for _, newTag := range request.Tags {
+		normalized := normalize(newTag.Name)
 		for i, oldTag := range book.Tags {
-			if newTag.Name == oldTag.Name {
+			if normalized == oldTag.Name {
 				newTag.ID = oldTag.ID
 				book.Tags[i].Deleted = false
 				break
@@ -348,6 +355,7 @@ func (h *Handler) ApiUpdateBookmark(w http.ResponseWriter, r *http.Request, ps h
 		}
 
 		if newTag.ID == 0 {
+			newTag.Name = normalized
 			book.Tags = append(book.Tags, newTag)
 		}
 	}


### PR DESCRIPTION
Editing a bookmark's tags only added new tags and never removed existing ones because ApiUpdateBookmark matched the incoming tag list against the stored tags case-sensitively on the raw text, while SaveBookmarks stores tags normalized to lowercase with collapsed whitespace. A tag whose casing or spacing changed in the edit box failed to match, so it stayed marked for deletion and was then re-inserted as a duplicate. Matching on the normalized name keeps tags that are still present and stops creating duplicates. Fixes #1167.