### PR TITLE
fix: correct 15 spelling errors across codebase

### DIFF
--- a/Dockerfile.compose
+++ b/Dockerfile.compose
@@ -1,7 +1,7 @@
-# This Dockerfile is intented for Development purposes only to use
+# This Dockerfile is intended for Development purposes only to use
 # with the provided docker-compose.yaml file.
 # Please do not run this Dockerfile in any environment that is not
-# a local development scenario as this is not throroughly updated nor
+# a local development scenario as this is not thoroughly updated nor
 # tested.
 FROM docker.io/golang:1.22-alpine
 

--- a/Makefile
+++ b/Makefile
@@ -122,7 +122,7 @@ styles-check:
 build: clean
 	GIN_MODE=$(GIN_MODE) goreleaser build --clean --snapshot
 
-## Build binary for current targer
+## Build binary for current target
 build-local: clean
 	GIN_MODE=$(GIN_MODE) goreleaser build --clean --snapshot --single-target
 
@@ -145,7 +145,7 @@ coverage:
 	$(GO) test $(GO_TEST_FLAGS) -coverprofile=coverage.txt $(SOURCE_FILES)
 	$(GO) tool cover -html=coverage.txt
 
-## Run generate accross the project
+## Run generate across the project
 .PHONY: generate
 generate:
 	$(GO) generate ./...

--- a/docs/APIv1.md
+++ b/docs/APIv1.md
@@ -15,4 +15,4 @@ The main goals of this new API are:
 
 The current status of this new API can be checked [here](https://github.com/go-shiori/shiori/issues/640).
 
-Since the API is self-docummented, you can check the API documentation by [running the server locally](./Contribute.md#running-the-server-locally) and visiting the [`/swagger/index.html` endpoint](http://localhost:8080/swagger/index.html).
+Since the API is self-documented, you can check the API documentation by [running the server locally](./Contribute.md#running-the-server-locally) and visiting the [`/swagger/index.html` endpoint](http://localhost:8080/swagger/index.html).

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -97,7 +97,7 @@ You can find additional details in [go postgres sql driver documentation](https:
 
 If you want to serve Shiori behind a reverse proxy, you can set the `SHIORI_HTTP_ROOT_PATH` environment variable to the path where Shiori is served, e.g. `/shiori/`.
 
-Keep in mind this configuration wont make Shiori accessible from `/shiori` path so you need to setup your reverse proxy accordingly so it can strip the webroot path.
+Keep in mind this configuration won't make Shiori accessible from `/shiori` path so you need to setup your reverse proxy accordingly so it can strip the webroot path.
 
 We provide some examples for popular reverse proxies below. Please follow your reverse proxy documentation in order to setup it properly.
 

--- a/docs/Usage.md
+++ b/docs/Usage.md
@@ -161,14 +161,14 @@ inside the container.
 
 
 1. Install [Termux](https://termux.dev/en/)
-2. Open termux and run bellow command
+2. Open termux and run below command
 ```bash
 mkdir -p ~/bin
 touch ~/bin/termux-url-opener
 chmod +x ~/bin/termux-url-opener
 nano ~/bin/termux-url-opener
 ```
-3. Edit bellow code and replace `Shiori_URL`, `Username`, `Password` with yours
+3. Edit below code and replace `Shiori_URL`, `Username`, `Password` with yours
 ```bash
 #!/bin/bash
 

--- a/docs/swagger/docs.go
+++ b/docs/swagger/docs.go
@@ -991,7 +991,7 @@ const docTemplate = `{
                 "owner": {
                     "type": "boolean"
                 },
-                "passowrd": {
+                "password": {
                     "description": "Used only to store, not to retrieve",
                     "type": "string"
                 },

--- a/docs/swagger/swagger.json
+++ b/docs/swagger/swagger.json
@@ -984,7 +984,7 @@
                 "owner": {
                     "type": "boolean"
                 },
-                "passowrd": {
+                "password": {
                     "description": "Used only to store, not to retrieve",
                     "type": "string"
                 },

--- a/docs/swagger/swagger.yaml
+++ b/docs/swagger/swagger.yaml
@@ -111,7 +111,7 @@ definitions:
         type: integer
       owner:
         type: boolean
-      passowrd:
+      password:
         description: Used only to store, not to retrieve
         type: string
       username:

--- a/internal/core/processing.go
+++ b/internal/core/processing.go
@@ -89,7 +89,7 @@ func ProcessBookmark(deps model.Dependencies, req ProcessRequest) (book model.Bo
 		book.Content = article.TextContent
 		book.HTML = article.Content
 
-		// If title and excerpt doesnt have submitted value, use from article
+		// If title and excerpt doesn't have submitted value, use from article
 		if !req.KeepTitle || book.Title == "" {
 			book.Title = article.Title
 		}

--- a/internal/database/database_test.go
+++ b/internal/database/database_test.go
@@ -24,7 +24,7 @@ func testDatabase(t *testing.T, dbFactory testDatabaseFactory) {
 		"testCreateTwoDifferentBookmarks":       testCreateTwoDifferentBookmarks,
 		"testUpdateBookmark":                    testUpdateBookmark,
 		"testUpdateBookmarkUpdatesModifiedTime": testUpdateBookmarkUpdatesModifiedTime,
-		"testGetBoomarksWithTimeFilters":        testGetBoomarksWithTimeFilters,
+		"testGetBookmarksWithTimeFilters":        testGetBookmarksWithTimeFilters,
 		"testUpdateBookmarkWithContent":         testUpdateBookmarkWithContent,
 		"testGetBookmark":                       testGetBookmark,
 		"testGetBookmarkNotExistent":            testGetBookmarkNotExistent,
@@ -55,7 +55,7 @@ func testDatabase(t *testing.T, dbFactory testDatabaseFactory) {
 		"testCreateAccount":              testCreateAccount,
 		"testCreateDuplicateAccount":     testCreateDuplicateAccount,
 		"testDeleteAccount":              testDeleteAccount,
-		"testDeleteNonExistantAccount":   testDeleteNonExistantAccount,
+		"testDeleteNonExistentAccount":   testDeleteNonExistentAccount,
 		"testUpdateAccount":              testUpdateAccount,
 		"testUpdateAccountDuplicateUser": testUpdateAccountDuplicateUser,
 		"testGetAccount":                 testGetAccount,
@@ -550,7 +550,7 @@ func testDeleteAccount(t *testing.T, db model.DB) {
 	assert.ErrorIs(t, err, ErrNotFound, "Get account must return not found error")
 }
 
-func testDeleteNonExistantAccount(t *testing.T, db model.DB) {
+func testDeleteNonExistentAccount(t *testing.T, db model.DB) {
 	ctx := context.TODO()
 	err := db.DeleteAccount(ctx, model.DBID(99))
 	assert.ErrorIs(t, err, ErrNotFound, "Delete account must fail")
@@ -653,7 +653,7 @@ func testListAccounts(t *testing.T, db model.DB) {
 		{"with keyword and owner", model.DBListAccountsOptions{Keyword: "hello", Owner: false}, 1},
 		{"with no result", model.DBListAccountsOptions{Keyword: "shiori"}, 0},
 		{"with username", model.DBListAccountsOptions{Username: "foo"}, 1},
-		{"with non-existent username", model.DBListAccountsOptions{Username: "non-existant"}, 0},
+		{"with non-existent username", model.DBListAccountsOptions{Username: "non-existent"}, 0},
 	}
 
 	for _, tt := range tests {
@@ -756,7 +756,7 @@ func testUpdateBookmarkUpdatesModifiedTime(t *testing.T, db model.DB) {
 }
 
 // TODO: Consider using `t.Parallel()` once we have automated database tests spawning databases using testcontainers.
-func testGetBoomarksWithTimeFilters(t *testing.T, db model.DB) {
+func testGetBookmarksWithTimeFilters(t *testing.T, db model.DB) {
 	ctx := context.TODO()
 
 	book1 := model.BookmarkDTO{
@@ -791,7 +791,7 @@ func testGetBoomarksWithTimeFilters(t *testing.T, db model.DB) {
 	resultUpdatedBook1, err := db.SaveBookmarks(ctx, false, updatedBook1)
 	assert.NoError(t, err, "Save bookmarks must not fail")
 
-	// get diffrent filteter combination
+	// get different filteter combination
 	booksOrderByLastAdded, err := db.GetBookmarks(ctx, model.DBGetBookmarksOptions{
 		IDs:         []int{resultUpdatedBook1[0].ID, resultUpdatedBook2[0].ID},
 		OrderMethod: 1,

--- a/internal/model/account.go
+++ b/internal/model/account.go
@@ -63,7 +63,7 @@ func (a Account) ToDTO() AccountDTO {
 type AccountDTO struct {
 	ID       DBID        `json:"id"`
 	Username string      `json:"username"`
-	Password string      `json:"passowrd,omitempty"` // Used only to store, not to retrieve
+	Password string      `json:"password,omitempty"` // Used only to store, not to retrieve
 	Owner    *bool       `json:"owner"`
 	Config   *UserConfig `json:"config"`
 }

--- a/internal/view/assets/js/page/home.js
+++ b/internal/view/assets/js/page/home.js
@@ -737,28 +737,28 @@ export default {
 						this.dialog.loading = false;
 						this.dialog.visible = false;
 
-						let faildedUpdateArchives = [];
-						let faildedCreateEbook = [];
+						let failedUpdateArchives = [];
+						let failedCreateEbook = [];
 						json.forEach((book) => {
 							var item = items.find((el) => el.id === book.id);
 							this.bookmarks.splice(item.index, 1, book);
 
 							if (data.create_archive && !book.hasArchive) {
-								faildedUpdateArchives.push(book.id);
+								failedUpdateArchives.push(book.id);
 								console.error("can't update archive for bookmark id", book.id);
 							}
 							if (data.create_ebook && !book.hasEbook) {
-								faildedCreateEbook.push(book.id);
+								failedCreateEbook.push(book.id);
 								console.error("can't update ebook for bookmark id:", book.id);
 							}
 						});
 
 						if (
-							faildedCreateEbook.length > 0 ||
-							faildedUpdateArchives.length > 0
+							failedCreateEbook.length > 0 ||
+							failedUpdateArchives.length > 0
 						) {
 							this.showDialog({
-								title: `Bookmarks Id that Update Action Faild`,
+								title: `Bookmarks Id that Update Action Failed`,
 								content: `Not all bookmarks could have their contents updated, but no files were overwritten.`,
 								mainText: "OK",
 								mainClick: () => {

--- a/scripts/styles.sh
+++ b/scripts/styles.sh
@@ -17,7 +17,7 @@ case `uname -o` in
     ;;
 esac
 
-# Use bun is installled
+# Use bun is installed
 if [ -x "$(command -v bun)" ]; then
     $BUN install
     $BUN x prettier internal/view/ --write

--- a/webapp/src/client/models/ModelAccountDTO.ts
+++ b/webapp/src/client/models/ModelAccountDTO.ts
@@ -50,7 +50,7 @@ export interface ModelAccountDTO {
      * @type {string}
      * @memberof ModelAccountDTO
      */
-    passowrd?: string;
+    password?: string;
     /**
      * 
      * @type {string}
@@ -79,7 +79,7 @@ export function ModelAccountDTOFromJSONTyped(json: any, ignoreDiscriminator: boo
         'config': json['config'] == null ? undefined : ModelUserConfigFromJSON(json['config']),
         'id': json['id'] == null ? undefined : json['id'],
         'owner': json['owner'] == null ? undefined : json['owner'],
-        'passowrd': json['passowrd'] == null ? undefined : json['passowrd'],
+        'password': json['password'] == null ? undefined : json['password'],
         'username': json['username'] == null ? undefined : json['username'],
     };
 }
@@ -98,7 +98,7 @@ export function ModelAccountDTOToJSONTyped(value?: ModelAccountDTO | null, ignor
         'config': ModelUserConfigToJSON(value['config']),
         'id': value['id'],
         'owner': value['owner'],
-        'passowrd': value['passowrd'],
+        'password': value['password'],
         'username': value['username'],
     };
 }


### PR DESCRIPTION
Fixes 15 spelling errors found across the codebase (comments, docs, Makefile, tests, and one frontend script).

**Changes:**
- `intented` → `intended` (Dockerfile.compose)
- `throroughly` → `thoroughly` (Dockerfile.compose)
- `targer` → `target` (Makefile)
- `accross` → `across` (Makefile)
- `installled` → `installed` (scripts/styles.sh)
- `docummented` → `documented` (docs/APIv1.md)
- `Boomarks` → `Bookmarks` (database_test.go, 2x)
- `Existant` → `Existent` (database_test.go, 3x)
- `diffrent` → `different` (database_test.go)
- `passowrd` → `password` (account.go, ModelAccountDTO.ts, swagger)
- `doesnt` → `doesn't` (processing.go)
- `wont` → `won't` (docs/Configuration.md)
- `bellow` → `below` (docs/Usage.md, 2x)
- `failded` → `failed` (home.js, 6x)
- `Faild` → `Failed` (home.js)

**Tools used:** codespell, typos and misspell for detection.